### PR TITLE
split connection string to protocol and host

### DIFF
--- a/config/crd/bases/atlas.mongodb.com_atlasservices.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasservices.yaml
@@ -113,9 +113,13 @@ spec:
                         description: AtlasClusterService defines the observed state
                           of AtlasClusterService
                         properties:
-                          conectionString:
-                            description: ConnectionString is the mongodb+srv://<host>
-                              connection URL for the cluster
+                          conectionHost:
+                            description: ConnectionHost is the cluster connection
+                              host
+                            type: string
+                          conectionProtocol:
+                            description: ConnectionProtocol is the protocol for cluster
+                              connection, "mongodb+srv"
                             type: string
                           id:
                             description: The ID of the Atlas Project

--- a/deploy/all-in-one.yaml
+++ b/deploy/all-in-one.yaml
@@ -120,9 +120,13 @@ spec:
                         description: AtlasClusterService defines the observed state
                           of AtlasClusterService
                         properties:
-                          conectionString:
-                            description: ConnectionString is the mongodb+srv://<host>
-                              connection URL for the cluster
+                          conectionHost:
+                            description: ConnectionHost is the cluster connection
+                              host
+                            type: string
+                          conectionProtocol:
+                            description: ConnectionProtocol is the protocol for cluster
+                              connection, "mongodb+srv"
                             type: string
                           id:
                             description: The ID of the Atlas Project

--- a/pkg/api/v1/status/atlasservice.go
+++ b/pkg/api/v1/status/atlasservice.go
@@ -61,9 +61,13 @@ type AtlasClusterService struct {
 	// +optional
 	RegionName string `json:"regionName,omitempty"`
 
-	// ConnectionString is the mongodb+srv://<host> connection URL for the cluster
+	// ConnectionProtocol is the protocol for cluster connection, "mongodb+srv"
 	// +optional
-	ConnectionString string `json:"conectionString,omitempty"`
+	ConnectionProtocol string `json:"conectionProtocol,omitempty"`
+
+	// ConnectionHost is the cluster connection host
+	// +optional
+	ConnectionHost string `json:"conectionHost,omitempty"`
 }
 
 // AtlasServiceStatus defines the observed state of AtlasService

--- a/pkg/controller/atlasservice/service.go
+++ b/pkg/controller/atlasservice/service.go
@@ -2,6 +2,7 @@ package atlasservice
 
 import (
 	"context"
+	"strings"
 
 	"go.mongodb.org/atlas/mongodbatlas"
 
@@ -14,30 +15,41 @@ func (r *AtlasServiceReconciler) discoverServices(ctx *workflow.Context) ([]stat
 	// Try to find the service
 	projects, _, err := ctx.Client.Projects.GetAllProjects(context.Background(), &mongodbatlas.ListOptions{})
 	if err != nil {
-		return nil, workflow.Terminate(workflow.ProjectNotCreatedInAtlas, err.Error())
+		return nil, workflow.Terminate(workflow.AtlasProjectsListFailed, err.Error())
 	}
 	svcList := []status.AtlasProjectService{}
 	for _, p := range projects.Results {
 
 		clusters, _, err := ctx.Client.Clusters.List(context.Background(), p.ID, &mongodbatlas.ListOptions{})
 		if err != nil {
-			return nil, workflow.Terminate(workflow.ProjectNotCreatedInAtlas, err.Error())
+			return nil, workflow.Terminate(workflow.AtlasClustersListFailed, err.Error())
 		}
 		clusterList := []status.AtlasClusterService{}
 		for _, cluster := range clusters {
+			connStrTokens := strings.Split(cluster.ConnectionStrings.StandardSrv, "://")
+			var protocol, host string
+			if len(connStrTokens) < 2 {
+				//There is no "://" found
+				protocol = ""
+				host = connStrTokens[0]
+			} else {
+				protocol = connStrTokens[0]
+				host = connStrTokens[1]
+			}
 			clusterSvc := status.AtlasClusterService{
-				ID:               cluster.ID,
-				Name:             cluster.Name,
-				InstanceSizeName: cluster.ProviderSettings.InstanceSizeName,
-				ProviderName:     cluster.ProviderSettings.ProviderName,
-				RegionName:       cluster.ProviderSettings.RegionName,
-				ConnectionString: cluster.ConnectionStrings.StandardSrv,
+				ID:                 cluster.ID,
+				Name:               cluster.Name,
+				InstanceSizeName:   cluster.ProviderSettings.InstanceSizeName,
+				ProviderName:       cluster.ProviderSettings.ProviderName,
+				RegionName:         cluster.ProviderSettings.RegionName,
+				ConnectionProtocol: protocol,
+				ConnectionHost:     host,
 			}
 			clusterList = append(clusterList, clusterSvc)
 		}
 		dbUsers, _, err := ctx.Client.DatabaseUsers.List(context.Background(), p.ID, &mongodbatlas.ListOptions{})
 		if err != nil {
-			return nil, workflow.Terminate(workflow.ProjectNotCreatedInAtlas, err.Error())
+			return nil, workflow.Terminate(workflow.AtlasDBUsersListFailed, err.Error())
 		}
 		dbUserList := []string{}
 		for _, dbUser := range dbUsers {

--- a/pkg/controller/workflow/reason.go
+++ b/pkg/controller/workflow/reason.go
@@ -36,3 +36,10 @@ const (
 	DatabaseUserInvalidSpec                 ConditionReason = "DatabaseUserInvalidSpec"
 	DatabaseUserExpired                     ConditionReason = "DatabaseUserExpired"
 )
+
+// Atlas Service discovery reasons
+const (
+	AtlasProjectsListFailed ConditionReason = "AtlasProjectsListFailed"
+	AtlasClustersListFailed ConditionReason = "AtlasClustersListFailed"
+	AtlasDBUsersListFailed  ConditionReason = "AtlasDBUsersListFailed"
+)


### PR DESCRIPTION
Atlas connection string is in the format: mongodb+srv://dbcreatedinatalas.iojsa.mongodb.net. We split it into two parts: protocol and host to allow easier handling in the service binding operator annotation mappings.