### PR TITLE
DBAAS-71 Deploy Refactored Atlas Operator with OLM and create DBaaS registration configmap during start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,12 +29,14 @@ BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
 endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
+# Image URL to use all building/pushing image targets
+IMG ?= controller:$(VERSION)
+
 # BUNDLE_IMG defines the image:tag used for the bundle.
-# You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
 BUNDLE_IMG ?= controller-bundle:$(VERSION)
 
-# Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+# The image tag given to the resulting catalog image (e.g. make catalog-build CATALOG_IMG=example.com/operator-catalog:0.2.0).
+CATALOG_IMG ?= controller-catalog:$(VERSION)
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -136,15 +138,22 @@ rm -rf $$TMP_DIR ;\
 endef
 
 .PHONY: bundle
-bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
+bundle: manifests kustomize ## Generate bundle manifests and metadata, update security context for OpenShift, then validate generated files.
 	operator-sdk generate kustomize manifests -q --apis-dir=pkg/api
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build --load-restrictor LoadRestrictionsNone config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+	sed -i .bak '/runAsNonRoot: true/d' "./bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml"
+	sed -i .bak '/runAsUser: 2000/d' "./bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml"
+	rm ./bundle/manifests/*.bak
 	operator-sdk bundle validate ./bundle
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
 	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+
+.PHONY: bundle-push
+bundle-push: ## Push the bundle image.
+	docker push $(BUNDLE_IMG)
 
 docker-build: ## Build the docker image
 	docker build -t ${IMG} .
@@ -164,3 +173,41 @@ stop-kind: ## Stop the local kind cluster
 .PHONY: log
 log: ## View manager logs
 	kubectl logs deploy/mongodb-atlas-operator manager -n mongodb-atlas-system -f
+
+.PHONY: opm
+OPM = ./bin/opm
+opm: ## Download opm locally if necessary.
+ifeq (,$(wildcard $(OPM)))
+ifeq (,$(shell which opm 2>/dev/null))
+	@{ \
+	set -e ;\
+	mkdir -p $(dir $(OPM)) ;\
+	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.17.3/$${OS}-$${ARCH}-opm ;\
+	chmod +x $(OPM) ;\
+	}
+else
+OPM = $(shell which opm)
+endif
+endif
+
+# A comma-separated list of bundle images (e.g. make catalog-build BUNDLE_IMGS=example.com/operator-bundle:v0.1.0,example.com/operator-bundle:v0.2.0).
+# These images MUST exist in a registry and be pull-able.
+BUNDLE_IMGS ?= $(BUNDLE_IMG)
+
+# Set CATALOG_BASE_IMG to an existing catalog image tag to add $BUNDLE_IMGS to that image.
+ifneq ($(origin CATALOG_BASE_IMG), undefined)
+FROM_INDEX_OPT := --from-index $(CATALOG_BASE_IMG)
+endif
+
+# Build a catalog image by adding bundle images to an empty catalog using the operator package manager tool, 'opm'.
+# This recipe invokes 'opm' in 'semver' bundle add mode. For more information on add modes, see:
+# https://github.com/operator-framework/community-operators/blob/7f1438c/docs/packaging-operator.md#updating-your-existing-operator
+.PHONY: catalog-build
+catalog-build: opm ## Build a catalog image.
+	$(OPM) index add --container-tool docker --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
+
+# Push the catalog image.
+.PHONY: catalog-push
+catalog-push: ## Push a catalog image.
+	$(MAKE) docker-push IMG=$(CATALOG_IMG)

--- a/PROJECT
+++ b/PROJECT
@@ -1,31 +1,55 @@
 domain: mongodb.com
-layout: go.kubebuilder.io/v3
-projectName: mongodb-atlas-kubernetes
-repo: github.com/mongodb/mongodb-atlas-kubernetes
-resources:
-- crdVersion: v1
-  group: atlas
-  kind: AtlasCluster
-  version: v1
-- crdVersion: v1
-  group: atlas
-  kind: AtlasProject
-  version: v1
-- crdVersion: v1
-  group: atlas
-  kind: AtlasDatabaseUser
-  version: v1
-- crdVersion: v1
-  domain: redhat.com
-  group: dbaas
-  kind: MongoDBAtlasConnection
-  version: v1alpha1
-- crdVersion: v1
-  domain: redhat.com
-  group: dbaas
-  kind: MongoDBAtlasInventory
-  version: v1alpha1
-version: "3"
+layout:
+- go.kubebuilder.io/v3
 plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}
+projectName: mongodb-atlas-kubernetes
+repo: github.com/mongodb/mongodb-atlas-kubernetes
+resources:
+- api:
+    crdVersion: v1
+    namespaced: true
+  controller: true
+  domain: redhat.com
+  group: dbaas
+  kind: MongoDBAtlasConnection
+  path: github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/dbaas
+  version: v1alpha1
+- api:
+    crdVersion: v1
+    namespaced: true
+  controller: true
+  domain: redhat.com
+  group: dbaas
+  kind: MongoDBAtlasInventory
+  path: github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/dbaas
+  version: v1alpha1
+- api:
+    crdVersion: v1
+    namespaced: true
+  controller: true
+  domain: mongodb.com
+  group: atlas
+  kind: AtlasCluster
+  path: github.com/mongodb/mongodb-atlas-kubernetes/pkg/api
+  version: v1
+- api:
+    crdVersion: v1
+    namespaced: true
+  controller: true
+  domain: mongodb.com
+  group: atlas
+  kind: AtlasDatabaseUser
+  path: github.com/mongodb/mongodb-atlas-kubernetes/pkg/api
+  version: v1
+- api:
+    crdVersion: v1
+    namespaced: true
+  controller: true
+  domain: mongodb.com
+  group: atlas
+  kind: AtlasProject
+  path: github.com/mongodb/mongodb-atlas-kubernetes/pkg/api
+  version: v1
+version: "3"

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -1,17 +1,21 @@
 FROM scratch
 
+# Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=mongodb-atlas-kubernetes
 LABEL operators.operatorframework.io.bundle.channels.v1=beta
 LABEL operators.operatorframework.io.bundle.channel.default.v1=beta
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.4.2
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.7.1
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
-LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
-LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 
+# Labels for testing.
+LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
+LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
+
+# Copy files to locations specified by labels.
 COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/
 COPY bundle/tests/scorecard /tests/scorecard/

--- a/bundle/manifests/dbaas.redhat.com_mongodbatlasconnections.yaml
+++ b/bundle/manifests/dbaas.redhat.com_mongodbatlasconnections.yaml
@@ -1,0 +1,123 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: mongodbatlasconnections.dbaas.redhat.com
+spec:
+  group: dbaas.redhat.com
+  names:
+    kind: MongoDBAtlasConnection
+    listKind: MongoDBAtlasConnectionList
+    plural: mongodbatlasconnections
+    singular: mongodbatlasconnection
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MongoDBAtlasConnection is the Schema for the MongoDBAtlasConnections API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DBaaSConnectionSpec defines the desired state of DBaaSConnection
+            properties:
+              instanceID:
+                description: The ID of the instance to connect to, as seen in the Status of the referenced DBaaSInventory
+                type: string
+              inventory:
+                description: A reference to the relevant DBaaSInventory CR
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+            required:
+            - instanceID
+            - inventory
+            type: object
+          status:
+            description: DBaaSConnectionStatus defines the observed state of DBaaSConnection
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              connectionInfo:
+                additionalProperties:
+                  type: string
+                description: Any other provider-specific information related to this connection
+                type: object
+              connectionString:
+                description: The connection string for this instance
+                type: string
+              credentialsRef:
+                description: Secret holding username and password
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/bundle/manifests/dbaas.redhat.com_mongodbatlasinventories.yaml
+++ b/bundle/manifests/dbaas.redhat.com_mongodbatlasinventories.yaml
@@ -1,0 +1,131 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: mongodbatlasinventories.dbaas.redhat.com
+spec:
+  group: dbaas.redhat.com
+  names:
+    kind: MongoDBAtlasInventory
+    listKind: MongoDBAtlasInventoryList
+    plural: mongodbatlasinventories
+    singular: mongodbatlasinventory
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MongoDBAtlasInventory is the Schema for the MongoDBAtlasInventory API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DBaaSInventorySpec defines the desired state of DBaaSInventory
+            properties:
+              credentialsRef:
+                description: The secret storing the vendor-specific connection credentials to use with the API endpoint. The secret may be placed in a separate namespace to control access.
+                properties:
+                  name:
+                    description: The name for object of known type
+                    type: string
+                  namespace:
+                    description: The namespace where object of known type is store
+                    type: string
+                type: object
+            required:
+            - credentialsRef
+            type: object
+          status:
+            description: DBaaSInventoryStatus defines the observed state of DBaaSInventory
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              instances:
+                description: A list of instances returned from querying the DB provider
+                items:
+                  properties:
+                    extraInfo:
+                      additionalProperties:
+                        type: string
+                      description: Any other provider-specific information related to this instance
+                      type: object
+                    instanceID:
+                      description: The ID for this instance in the database service
+                      type: string
+                    name:
+                      description: The name of this instance in the database service
+                      type: string
+                  required:
+                  - instanceID
+                  type: object
+                type: array
+              type:
+                description: E.g., MongoDB, Postgres
+                type: string
+            required:
+            - type
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
+++ b/bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
@@ -60,14 +60,43 @@ metadata:
               }
             ]
           }
+        },
+        {
+          "apiVersion": "dbaas.redhat.com/v1alpha1",
+          "kind": "MongoDBAtlasConnection",
+          "metadata": {
+            "name": "test-connection"
+          },
+          "spec": {
+            "instanceID": "606b2ffbc9a90e310e642482",
+            "inventory": {
+              "name": "test-inventory"
+            }
+          }
+        },
+        {
+          "apiVersion": "dbaas.redhat.com/v1alpha1",
+          "kind": "MongoDBAtlasInventory",
+          "metadata": {
+            "name": "test-inventory"
+          },
+          "spec": {
+            "credentialsRef": {
+              "name": "my-atlas-key",
+              "namespace": "mongodb-atlas-system"
+            },
+            "provider": {
+              "name": "mongodbatlas"
+            }
+          }
         }
       ]
     capabilities: Basic Install
     categories: Database
     description: The MongoDB Atlas Kubernetes Operator enables easy management of Clusters in MongoDB Atlas
-    operators.operatorframework.io/builder: operator-sdk-v1.4.2
+    operators.operatorframework.io/builder: operator-sdk-v1.7.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: mongodb-atlas-kubernetes.v0.5.0
+  name: mongodb-atlas-kubernetes.v0.6.7
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -88,6 +117,16 @@ spec:
       kind: AtlasProject
       name: atlasprojects.atlas.mongodb.com
       version: v1
+    - description: MongoDBAtlasConnection is the Schema for the MongoDBAtlasConnections API
+      displayName: Mongo DBAtlas Connection
+      kind: MongoDBAtlasConnection
+      name: mongodbatlasconnections.dbaas.redhat.com
+      version: v1alpha1
+    - description: MongoDBAtlasInventory is the Schema for the MongoDBAtlasInventory API
+      displayName: Mongo DBAtlas Inventory
+      kind: MongoDBAtlasInventory
+      name: mongodbatlasinventories.dbaas.redhat.com
+      version: v1alpha1
   description: |
     The MongoDB Atlas Operator provides a native integration between the Kubernetes orchestration platform and MongoDB Atlas —
     the only multi-cloud document database service that gives you the versatility you need to build sophisticated and resilient applications that can adapt to changing customer demands and market trends.
@@ -209,6 +248,30 @@ spec:
       - rules:
         - apiGroups:
           - ""
+          resourceNames:
+          - mongodb-atlas-registration
+          resources:
+          - configmaps
+          verbs:
+          - create
+          - get
+          - list
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - ""
           resources:
           - secrets
           verbs:
@@ -280,6 +343,46 @@ spec:
           - patch
           - update
         - apiGroups:
+          - dbaas.redhat.com
+          resources:
+          - mongodbatlasconnections
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - dbaas.redhat.com
+          resources:
+          - mongodbatlasconnections/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - dbaas.redhat.com
+          resources:
+          - mongodbatlasinventories
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - dbaas.redhat.com
+          resources:
+          - mongodbatlasinventories/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
           - authentication.k8s.io
           resources:
           - tokenreviews
@@ -315,7 +418,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443
@@ -337,7 +440,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: mongodb/mongodb-atlas-kubernetes-operator:0.5.0
+                image: quay.io/ecosystem-appeng/mongodb-atlas-operator:0.6.7
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:
@@ -362,8 +465,6 @@ spec:
                 securityContext:
                   allowPrivilegeEscalation: false
               securityContext:
-                runAsNonRoot: true
-                runAsUser: 2000
               serviceAccountName: mongodb-atlas-operator
               terminationGracePeriodSeconds: 10
       permissions:
@@ -392,7 +493,7 @@ spec:
         serviceAccountName: mongodb-atlas-operator
     strategy: deployment
   installModes:
-  - supported: false
+  - supported: true
     type: OwnNamespace
   - supported: false
     type: SingleNamespace
@@ -415,4 +516,4 @@ spec:
   maturity: beta
   provider:
     name: MongoDB, Inc
-  version: 0.5.0
+  version: 0.6.7

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -1,12 +1,15 @@
 annotations:
-  operators.operatorframework.io.bundle.channel.default.v1: beta
-  operators.operatorframework.io.bundle.channels.v1: beta
-  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  # Core bundle annotations.
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: mongodb-atlas-kubernetes
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.4.2
+  operators.operatorframework.io.bundle.channels.v1: beta
+  operators.operatorframework.io.bundle.channel.default.v1: beta
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.7.1
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
-  operators.operatorframework.io.test.config.v1: tests/scorecard/
+
+  # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -5,6 +5,8 @@ resources:
 - bases/atlas.mongodb.com_atlasclusters.yaml
 - bases/atlas.mongodb.com_atlasprojects.yaml
 - bases/atlas.mongodb.com_atlasdatabaseusers.yaml
+- bases/dbaas.redhat.com_mongodbatlasconnections.yaml
+- bases/dbaas.redhat.com_mongodbatlasinventories.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,11 +1,11 @@
 resources:
-  - manager.yaml
+- manager.yaml
 
 generatorOptions:
   disableNameSuffixHash: true
-
-# Anton: not sure if the ConfigMap generated here by kubebuilder is used anywhere - so far let's omit it.
-#configMapGenerator:
-#  - name: manager-config
-#    files:
-#      - controller_manager_config.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: quay.io/ecosystem-appeng/mongodb-atlas-operator
+  newTag: 0.6.7

--- a/config/manifests/bases/mongodb-atlas-kubernetes.clusterserviceversion.yaml
+++ b/config/manifests/bases/mongodb-atlas-kubernetes.clusterserviceversion.yaml
@@ -27,6 +27,16 @@ spec:
       kind: AtlasProject
       name: atlasprojects.atlas.mongodb.com
       version: v1
+    - description: MongoDBAtlasConnection is the Schema for the MongoDBAtlasConnections API
+      displayName: Mongo DBAtlas Connection
+      kind: MongoDBAtlasConnection
+      name: mongodbatlasconnections.dbaas.redhat.com
+      version: v1alpha1
+    - description: MongoDBAtlasInventory is the Schema for the MongoDBAtlasInventory API
+      displayName: Mongo DBAtlas Inventory
+      kind: MongoDBAtlasInventory
+      name: mongodbatlasinventories.dbaas.redhat.com
+      version: v1alpha1
   description: |
     The MongoDB Atlas Operator provides a native integration between the Kubernetes orchestration platform and MongoDB Atlas —
     the only multi-cloud document database service that gives you the versatility you need to build sophisticated and resilient applications that can adapt to changing customer demands and market trends.
@@ -147,7 +157,7 @@ spec:
       deployments: null
     strategy: ""
   installModes:
-  - supported: false
+  - supported: true
     type: OwnNamespace
   - supported: false
     type: SingleNamespace
@@ -164,10 +174,10 @@ spec:
   links:
   - name: MongoDB Atlas Kubernetes
     url: https://github.com/mongodb/mongodb-atlas-kubernetes
-  maturity: beta
-  provider:
-    name: MongoDB, Inc
   maintainers:
   - email: support@mongodb.com
+    name: MongoDB, Inc
+  maturity: beta
+  provider:
     name: MongoDB, Inc
   version: 0.0.0

--- a/config/rbac/clusterwide/role.yaml
+++ b/config/rbac/clusterwide/role.yaml
@@ -7,11 +7,28 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  resourceNames:
+  - mongodb-atlas-registration
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+- apiGroups:
+  - ""
   resources:
   - events
   verbs:
   - create
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
 - apiGroups:
   - ""
   resources:
@@ -24,46 +41,6 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - atlas.mongodb.com
-  resources:
-  - MongoDBAtlasConnections
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - atlas.mongodb.com
-  resources:
-  - MongoDBAtlasConnections/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - atlas.mongodb.com
-  resources:
-  - MongoDBAtlasInventorys
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - atlas.mongodb.com
-  resources:
-  - MongoDBAtlasInventorys/status
-  verbs:
-  - get
-  - patch
-  - update
 - apiGroups:
   - atlas.mongodb.com
   resources:
@@ -120,6 +97,46 @@ rules:
   - atlas.mongodb.com
   resources:
   - atlasprojects/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - dbaas.redhat.com
+  resources:
+  - mongodbatlasconnections
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - dbaas.redhat.com
+  resources:
+  - mongodbatlasconnections/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - dbaas.redhat.com
+  resources:
+  - mongodbatlasinventories
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - dbaas.redhat.com
+  resources:
+  - mongodbatlasinventories/status
   verbs:
   - get
   - patch

--- a/config/rbac/namespaced/role.yaml
+++ b/config/rbac/namespaced/role.yaml
@@ -8,11 +8,28 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  resourceNames:
+  - mongodb-atlas-registration
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+- apiGroups:
+  - ""
   resources:
   - events
   verbs:
   - create
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
 - apiGroups:
   - ""
   resources:
@@ -25,46 +42,6 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - atlas.mongodb.com
-  resources:
-  - MongoDBAtlasConnections
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - atlas.mongodb.com
-  resources:
-  - MongoDBAtlasConnections/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - atlas.mongodb.com
-  resources:
-  - MongoDBAtlasInventorys
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - atlas.mongodb.com
-  resources:
-  - MongoDBAtlasInventorys/status
-  verbs:
-  - get
-  - patch
-  - update
 - apiGroups:
   - atlas.mongodb.com
   resources:
@@ -121,6 +98,46 @@ rules:
   - atlas.mongodb.com
   resources:
   - atlasprojects/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - dbaas.redhat.com
+  resources:
+  - mongodbatlasconnections
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - dbaas.redhat.com
+  resources:
+  - mongodbatlasconnections/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - dbaas.redhat.com
+  resources:
+  - mongodbatlasinventories
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - dbaas.redhat.com
+  resources:
+  - mongodbatlasinventories/status
   verbs:
   - get
   - patch

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -5,4 +5,6 @@ resources:
 - atlas_v1_atlascluster.yaml
 - atlas_v1_atlasproject.yaml
 - atlas_v1_atlasdatabaseuser.yaml
+- dbaas_v1alpha1_atlasconnection.yaml
+- dbaas_v1alpha1_atlasinventory.yaml
 # +kubebuilder:scaffold:manifestskustomizesamples

--- a/deploy/all-in-one.yaml
+++ b/deploy/all-in-one.yaml
@@ -1244,6 +1244,23 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  resourceNames:
+  - mongodb-atlas-registration
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
   resources:
   - secrets
   verbs:

--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/atlasdatabaseuser"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/atlasinventory"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/atlasproject"
+	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/dbaasregistration"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/watch"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/util/kube"
 	// +kubebuilder:scaffold:imports
@@ -115,6 +116,11 @@ func main() {
 		setupLog.Error(err, "unable to create clientset")
 		os.Exit(1)
 	}
+	if err := dbaasregistration.CreateAtlasRegistrationConfigMap(clientset, setupLog); err != nil {
+		setupLog.Error(err, "unable to create Provider Registration ConfigMap")
+		os.Exit(1)
+	}
+
 	if err = (&atlasconnection.MongoDBAtlasConnectionReconciler{
 		Client:          mgr.GetClient(),
 		Clientset:       clientset,

--- a/pkg/controller/atlasconnection/atlasconnection_controller.go
+++ b/pkg/controller/atlasconnection/atlasconnection_controller.go
@@ -73,12 +73,12 @@ type MongoDBAtlasConnectionReconciler struct {
 
 // Dev note: duplicate the permissions in both sections below to generate both Role and ClusterRoles
 
-// +kubebuilder:rbac:groups=atlas.mongodb.com,resources=MongoDBAtlasConnections,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=atlas.mongodb.com,resources=MongoDBAtlasConnections/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=dbaas.redhat.com,resources=mongodbatlasconnections,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=dbaas.redhat.com,resources=mongodbatlasconnections/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 
-// +kubebuilder:rbac:groups=atlas.mongodb.com,namespace=default,resources=MongoDBAtlasConnections,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=atlas.mongodb.com,namespace=default,resources=MongoDBAtlasConnections/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=dbaas.redhat.com,namespace=default,resources=mongodbatlasconnections,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=dbaas.redhat.com,namespace=default,resources=mongodbatlasconnections/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",namespace=default,resources=secrets,verbs=get;list;watch
 
 func (r *MongoDBAtlasConnectionReconciler) Reconcile(cx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/pkg/controller/atlasinventory/atlasinventory_controller.go
+++ b/pkg/controller/atlasinventory/atlasinventory_controller.go
@@ -51,12 +51,12 @@ type MongoDBAtlasInventoryReconciler struct {
 
 // Dev note: duplicate the permissions in both sections below to generate both Role and ClusterRoles
 
-// +kubebuilder:rbac:groups=atlas.mongodb.com,resources=MongoDBAtlasInventorys,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=atlas.mongodb.com,resources=MongoDBAtlasInventorys/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=dbaas.redhat.com,resources=mongodbatlasinventories,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=dbaas.redhat.com,resources=mongodbatlasinventories/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 
-// +kubebuilder:rbac:groups=atlas.mongodb.com,namespace=default,resources=MongoDBAtlasInventorys,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=atlas.mongodb.com,namespace=default,resources=MongoDBAtlasInventorys/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=dbaas.redhat.com,namespace=default,resources=mongodbatlasinventories,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=dbaas.redhat.com,namespace=default,resources=mongodbatlasinventories/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",namespace=default,resources=secrets,verbs=get;list;watch
 
 func (r *MongoDBAtlasInventoryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/pkg/controller/dbaasregistration/configmap.go
+++ b/pkg/controller/dbaasregistration/configmap.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2021 MongoDB.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dbaasregistration
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	name      = "mongodb-atlas-registration"
+	namespace = "dbaas-operator" // namespace where the configmap should be stored
+	data      = `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mongodb-atlas-registration
+  labels:
+    related-to: dbaas-operator
+    type: dbaas-provider-registration
+data:
+  provider: MongoDBAtlas
+  logo: |
+    data: iVBORw0KGgoAAAANSUhEUgAAAH8AAAB/CAYAAADGvR0TAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4ggYEhkp9JVi8gAAFENJREFUeNrtnXmcVeV5x7/Pe86dGUZQUdwAo4Kaam1cUAdm3DAYl1ZjmmhMYkUlkMYtMVVrVExqY7q4oabNp6EuMdpEq8ZGpf1oJCbKJgxqlWiIgIrACCgimwJznv5xlvue5d65dxjsvXPP4+d4t3OB+/7e37O/7wsNKhdNv9iZ8uqNQgOLadhfLnLA7CV/OOrT/3JMDn7D/XDh02s3bRr/h4ufz8FvNOnu1s9v2rL5/EZW+06j/eCJT09i1Pijdhb46ZpNGwa4Jw4x7097+9mGtHyN+KMn/fob/yyYK998byWLV727FXQPgfcXXjIjV/v9Uc7/nwkATHhq4t+q6pWKUjAOgroCf73wkhkc+KOOnPn9dwJceIkx5k6DwRjDyg/XsmD52+Eg7LHwkhkrc+b3Izl32nkAnDftgkcV7kRBUVQVxxhAw1ufOfBHHaaR2N+vwf/KE+fS7W0Z8LVp5z2t6BcIQPfhViSu9w4BLlt4yQxG3NmRg1/v8vO/uB/EmY3qOFDUC3iuiiq4xsHXBOAB3cptI+/s+KvFl87ggAaYAP3S5n/pV18WjNnBUZllxBwiAo44CIIYgxHBiMP6jzcxd8kixFIBAp7AV/546YyHcubXoXy03gVPf6noIaGS93xLT6DxAcU1DhIMQngJGFUe3P+OjhMB9r+jI2d+PciZj30JcUWkW6Yb5AQxBgeDiGCMYDCIBMw3ho82b2XOooUx5lviASe9cdmM6Tnz60AeO/NhdKveBHqCRgh6Edsjex+8doz0RIxn9r+j41BfA7TnzK9VGff0WbSu964V4QdGDIJgQpYHjyImYL/giKFblecXvo6RcsOgHrDHG5fNXN3fwHf7yw9pWbe1DZEbQNBoVvvPNHxHFSR8D1Q1dp/lECS14//uf0f7/t3CRuPBom/NzMGvFTnl4TP2VHS2IqAB3AKqgieKo4IHGAkifFVUFNcxKIogKdA1/rgXMGvJpTMPzW1+jcjJD5/u2y7hwZDJSRB9WIvve9FzP9YPX3kUn2vxFqR4fWbk7e33Aoy8vX/Y/7ot6Y576DSePutJTn749O+DjAd82y0SZe5EAk0QvCcUH0FA4K33VvvvV/bXHrbLqXu/suhbM1/LHb7/RznxodMwyJ+ImFccEdd36ASDH8b5Dl8Q3gVhXuj8SfC+4zg8+9rve3D40h4gMAp4sd5tf92q/elnT0PR/0Q914spdgJ1roE61+i1F5mAwMUT6S1h7u8PTl/dgj/2wVNvVThEAzx8e2/bdBJef2jMLd9Atbd//cEjb29/LAf/E5ZjfzGK439xyi6q+o2wQqfqUXT4Am8+8Nw8y7FLagXdtn/K50dMaT8OYMSU9hz8T0KeO6cTD+9nCq2hCbYJrBnPovvs/H4vma9avICHARZ/e2YO/ichHf9x0qkopyVr82GDBpE2KDZtqHWvhpogeL+lUCgJbtaVkN1GTGmfmqv97SyjH/hsyNfvpZMwCdWeUuqhdogS/CXB7oWcO2JK+3Bf/Y/Jwd8eMvtrzzD6gc8eC9rmqaXC1c/RqfoFHE81075HvgCWBthWq+//qS2gj+bM386i8IiStu+R8leNWXjb67dDvMgxrBp8zbgAOGrElDFfWPztWTn4fS2j7h/LkQ+ceKaiu0VAaqjOk2zGsvvF19ZDZPfRLPi1zFVWrgUYeduYHPy+ksPvH0vnub9B4W+8BGsjSGL2PAGVxplP4vt+Sb9igKMsjxDL+yPKqJG3jTl50eWzcvD7Sl489zccdv/Yg1T1mBg3LeRDhnuZXr+t/hNaQqHgOj1CngQ7OU+s4tCjAPvVCfvrQu2r6r1gVd80bs9Dey+AemrX7YqRgGrC69fIfJRgcnRF0YD1b7Avay607nfbmDPZsiUHf1vlT+87nkN+dsLexTRu3JVTjSduvIR6Twd8dhRgpX9LMzle6q3EMKheseSqeex36+gc/G2RBef9FlRPUWj1U7aaAEIDmy4Z6t1iOxpL+GA5gl4Gm8uC3HMWqGO/W0cftuQ7s3Pweyv73ndcyObJIavjSRvbU/fifrpGjVsxb59EgFecPGWZ3Jss0L/Wg9qv6Xr+gfcd1+bAbCeozTviPwrghvV6kUSzZrGG74hBwH8UgwiEzZ2OGFzH4dW3l7Fu00d9NhDBn7MROBh4a3ENa4CaVvuiXBxT82qHepbXL/HQL5b0EUmVedmGDJ/0cAXSCpyyuMZVf002cI786bEItCi021k5FX/4QxstqsWmXJGiLRcJ7vcfRSRKBdjNnapUFOb1LkJhMvBvuc2vUhaNfw6FQQojwyXVWM4YqjGvH5VEsVaLqd6MeN+2/64xlTA5Ow9ouQJe4lIYtu8tozty8HshnuqXvXj1naxcnP/cSyV80l4/VnJHoySPY6RH+kehnw2uVhT+fScHv3dyeXzwNeq/KC7FSoIdDwND0KP2bdUMSONM9rJY3Pty75H73jK6NQe/CtnvnvbBqowopmxJlWHTGkFT+Xs0I0ljN3daKrsS+98L+RSwRw5+hTL87na6VcbZ9hrNAFATmT6NR/Hx9K4mcoPxhVzbK4YOUsaX5uBXKO9cOBPfyy9n7232B80cVi9fmA3ESvhkNXdq34CbeVnz7KIc/OrkzzwbSEtd26ocqy+PhJOX8vpJN3d621DGreKrzfvc3HZYDn6lMTJ6UBHwEKSMjpykVlAt7fVnNHdGwEp5FvcMdrF+4GVcwMn73NyWg9+TDLtrtKMwFEpU5EJHzvrQixie5QymJ0LsDnuVZkUTMwvsHhVBx1tXzMkzfD1JNzLWsRmugooPsETZPcW/R2IFHN+DV8LQXVRRMUEKMPxMYgma0kxOmgoyzEdFmT6Aw3O1X5mM1WTEZoVu8UZMUmVem9BRCZdkG1eyEuBFXUAVMrks2BlFwOH73tS2Yw5+z2p1XFaRxqvI609z1s7yxU2HWhpfKmZ0T+X80DE0iQs4Kwe/Z/APTa6viK27s7J1ttdfbXOnJl35KsEtBXJ2TUABPSG3+WVkt7vaBgEFjaJ38JDAvqeZLyWehyAhQf+eiNXNE34mUcyvHiWrOJKeHxW7hQk5Jge/7JjJEBXfsfMiFoWUlcBpI3Lo1C7hkiz9UtxtJ6jrq6eokZRLJ71SgVrFXYL6qd5c7ZeRnYNwO8bwLAcs+VnKS1dKNnfaWT9T0ZYsPS/gKH4ieMHVHT33P9v7prYhOfglxIMhsZ46jdttuxQbX2xZfXNn2LpdcA3lV+lkAV0EtzsGspSLFATIwS/DsB2ChFtmNi9ksO39q/auuTMxfcpyPQ10hUo/mUhQHZTb/AwZPLUNYGcPMBQ3SkRBRYNuHX9m+EkeuyYnMTNgYuz3k0Rhy5f/OnQnQ21h+mKnDog2dSw5AXbJmZ8haybOQWFgejPEeMq2VJnXs5o7PXvcJavM62f7wnu9Sku7qki5q/y3BRiQg196bAfGnTVSS6/CnL5nq2dNLse2l2dZSR6NL+UuklIqA3vbf2IhB78MO7I8+hAkz4/YYuCFyzPC1TZZzZ3JvF9sJU/vmdwbGZiDX1r20MTOKWECx4uFcHFVrclevNhzDxL782BNKlNFzN7LjKU9iWtqkUxNJXkUXS+RI1bcDtlDMYHjpgkl7QXungabK4f7Knqov8LW2mhRk16/KK5r+gTgWGhaJ1Jj4LNOiDdlSjHHl1nmdaLPLc/fXqhhfU+iFR69a9hUa+ZplQpDtq+CqX/wSXFeLIb7QHsKjhAu0wlCQaxVPFb6N4rrJbg1SPwE6/3K9fFpKSZrDwCXvFcBNufgl5bV9vq7MMZPTweNGjnsoo79WTSVxAT2XvxCj81+wDHGdyQrZW85nd+zfJQ7fGXC/axxTfbc99Tc6VmsVs06REGjtK+UOGcnc+lWun+cKto+FFifM7+EeMqHRgJeBupcokRN0fe3tYOHX5zRmMkAzQKagP1Blg8tbuci2Wq6r2Vdzvwyah8oEcRlLbDKDKeKmoH4Hj6aTA6FMWTyeI3t55mtzcEvLe96mraimuq5tdV9Vmt3Yv+9jOROBLZsH7AzNm9SD97PwS+lEye9sCL8N6l1SEKsBaua5s4UlzXe3FltvFYZyLGyrtX7Lx6szMEvP5wvJ7N0sRi/THNnvAwbP1ghy2RUw/keQSZ74YclH6y4eu7WHPzy8lRy1L2kzdf4ku2wuTOaJJa697dlIb7lOumNmtKTJ35FUUCPK3pKNoXU3LGstQj+Q1piG1UyGJ+eFOk0bkyD2Dt3EqzBz4CqsrV5Ve3P+1QOfo92f+48YItmeP3pHn57V83k2XiasXmTvcwqDPO0t0yu9qf9Mge/Uruv2RF3chdNz8rwkfAPsvbwKf4hyZp+KTb3TYj3znfnrRr+D0fm4FcgL0SJnxJePwn7H2/uJHHAAtnNnfKJxfevArzz3Xk5+OVk0E+OAvh1qbNtyYj9yzd3SvxbGt+fY/NWb/vpr+JKn85aZFgt2nyAx1KAa7H33o6hY15/LOGTbACLO4ihryCS7BDoE7CT5mR6Dn7lE0CBB2MnY2Tw39um5s7q9+Cs8uQtW57Mwa9ObshKxKQOTbK47SXUf1ZzZywrCGwtofarBLec/Peya+ZtzcGvzu4vAV2qatvrDJ/cbu4kq7kzWeaNr+CNFmv2DdBZ8v1aZVetqn3WTZq7ybaVqdCbnps7S63vKzqF2tdAJ2UVsGDYD4+sSfBdaluuBh0fdubYnTqVNHfaZ+l4QStX6Cs4wfKfrVs9ZPv11M5fds28DTnze6H6102a2wU8mqnuS2yhni7zxhs8U3F/H1O/mBZWgB/WMrNqFvx1k+aGtv8GoDt5nl6m1x9L4JMq83qprKHS3e31GdhiOQ0Kbyy7Zt7vht84Kge/97LlZdClWXbf9vq9MsmfeEtXMczzAM+rDtwkyF54kSr1XgHwzrWdNTuyQh3IoJ8cdQzIc0b83nuDf7iC/drgvzYIjpHgeBWJ3ncQRARXgvtFcI1h2dtr6e7W9IBoOrNQhYFYA4wAPlhew+CbOgCedZPmPg88kQJBExk7SLR3pb38ZCa/e4sXi/GSTK66P9e/bll+bWdNA19HzD8a4EgR5orFcqF44FLI5kgDBIctOYGWcAIN4QQHNUnwuHTxB7339rNnxOrl13XuVg/jWhcnaq6b9ALrJr0wT5VfJcc9eyl3afarlfDxVCtlcjXl/OupE6mrI9SBs4H3SjV3UqK5UxNef/i1yNb3Sa8GAB8CU4f+YFRdDKZTT8hvfnxZd8sZwzYDp/gLMHwTQGACwv31JEjoiP+/xD3BcxG8bmXj2s29Nn4Zq3qOX35d59J101fkzN8esnbiC1OAWSFjk2pd1Gr7DmieLvMG3+khxq/wDL3w739i2XWdc4bVCevrEvydph4N8OcKG8s1dybbvWJl3lDtJ1ZoVnKsWtbqoOCMnosBll3XmYO/ndm/RtGrifFZMxI6JZo7g46eJnVioGeBXOqkrcT6/jNWTO58e6+/H1VX4yj1CP5OU49m7cQXGDy17QGBrxoJbHxWwkfEP1c3CgWLCZ8dNxZYvPK9aCMH6d3OGtMFxinoismdOfifhAT79g0E3jbCYBMAKhG4xcfoEGYER8LJIQzd0MpLq7p8h7B3of1moKVrcqfW4xiaegV/zcQ5rJk4Zz1whMLmrNZtteZ3uA9nsblTGZKxLV7lob0CjO2a3Kl71pm6r3vwQ/avmTjnTYGz00uxrJbu1N59/n+70lqy8aOcqxcUiW/smtw5E6CrztR9vwB/zcQ57DK1jfe+Pue/QCfan3lJniaaOz1gT7NDopOnCK4Em7IaDS+iS5Qfd02ef92QG4+o5+GrryRPlmx6fBm7/nsb7319zvwdzhg+FGFUmPAJfYAw4SPi+/Xhhk0dW4ay6OP32aAfR/UB0R5P0J4DfHHQ2L303cnz63rshH4mQ+4a/YhB/jL0+p0gCnCCvXfcwPFTUa7aeDRPbvgjszYsrdTpWwAcvvz6+Vv6w1iZfga8rJ4w+4vA42o5eGGyx473W9XFxfCZAXvSXaLAkzjQ4RWFY/sL8P0O/NUTZuvud41h5YRZZwC/S2b2bH9gL28gHsrQwo4MMG7ZjReAJQptmtgtrN7FpR/K7neNoQXGfgyPKZxerAKGXb7K8O5BYPxunt0Lg3hnc8m9kuYDY7uun7+pv42T6W8/aOWEWaycMIuPwevyNcDP7eSMBrt47OPthAq4jsMRA4exVb0spf8ydI+mxrZQy8HvQbomzGLoXWNYPmHmVxWuDIEHKOAwmBbECCKGk4ccxGB3QBTxB3H8j4FRXde/vKXr+vmag19nsnzCLIbd3c6yC2feDHxToRtgR68JFx94YwweylUjPkerFEB1M8qVXde/eBHB/f1VhAaSfe7p2FeQBQfozq3neAfhOAWaCk00NTXT3NyCNLXwT68/fvBzl097ba+/O5wV33uxX4+HaRTgP3V3B29dMOPNN2X50GO6h/mt38ZEl2NcWp3Cxc9dPu21S+/5Zr8HvuGYH8rUqVfc6zru+EKhiaZCE81NLTS3DFjluk0HGnE+OPGkCxtiHNxGBN8x5hERM96IwTEOxnEwxv39uM9N/KCRxsE0IvjGOAuNMVt8le/gOC6OcZ9tuHGgIUWXGuNsdYyDBPbecZyXcvAbQM6/4B83OkZWi3FwHRfHdTGOuzQHv2FUvzsj8vSdAq5bWJGD3zDgm07HMRingOO67DBghw9y8BvH43/diIPruriOi1tokhz8BvL4HccNVT5OoUAOfqP8cMdd5YPv4LpNFNzmHPxGkTPOvHyN4zg+8wtNNLe05OA3GPspuAUKhSYU2TkHv4Gk4BQ8t9BEU6GZ5qbmQTn4jeTxu4WX3EKBQnMzheaW3XPwG0Se++0DtB97zqjWloG7NhVa7m5pGjCYXBpHXlsQ3wZ/w/plDfX7/w9sJTyL9hMvGQAAAABJRU5ErkJggg==
+    mediatype: image/png
+  inventory_kind: MongoDBAtlasInventory
+  connection_kind: MongoDBAtlasConnection
+  credentials_fields: |
+    - key: orgId
+      display_name: Organization ID
+      type: string
+      required: true
+    - key: publicApiKey
+      display_name: Public API Key
+      type: string
+      required: true
+    - key: privateApiKey
+      display_name: Private API Key
+      type: maskedstring
+      required: true`
+)
+
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list
+// +kubebuilder:rbac:groups="",resources=configmaps,resourceNames=mongodb-atlas-registration,verbs=get;list;create
+// +kubebuilder:rbac:groups="",namespace=default,resources=namespaces,verbs=get;list
+// +kubebuilder:rbac:groups="",namespace=default,resources=configmaps,resourceNames=mongodb-atlas-registration,verbs=get;list;create
+
+// CreateAtlasRegistrationConfigMap creates a configmap for registration with Red Hat DBaaS Operator
+func CreateAtlasRegistrationConfigMap(clientSet *kubernetes.Clientset, log logr.Logger) error {
+	_, err := clientSet.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
+	if err != nil && errors.IsNotFound(err) {
+		// if dbaas-operator namespace does not exist, no registration is done
+		log.Info("DBaaS registration configmap creation is skipped as dbaas-operator namespace does not exist")
+		return nil
+	}
+	_, err = clientSet.CoreV1().ConfigMaps(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil && errors.IsNotFound(err) {
+		// the registration configmap does not exist, create one in dbaas-operator namespace
+		jsonData, err := yaml.ToJSON([]byte(data))
+		if err != nil {
+			return err
+		}
+		cm := &corev1.ConfigMap{}
+		err = json.Unmarshal(jsonData, cm)
+		if err != nil {
+			return err
+		}
+		_, err = clientSet.CoreV1().ConfigMaps(namespace).Create(context.Background(), cm, metav1.CreateOptions{})
+		if err != nil {
+			// failed to create the configmap
+			return err
+		}
+		log.Info("DBaaS registration configmap is created in dbaas-operator namespace")
+		return nil
+	}
+	if err == nil {
+		log.Info("DBaaS registration configmap already exists in dbaas-operator namespace")
+	}
+	return err
+}


### PR DESCRIPTION
Added the following:
1) Deploy Refactored Atlas Operator with OLM
2) Create DBaaS registration configmap when Atlas operator starts if dbaas-operator namespace exists.