### PR TITLE
Remove namespace level installment via OLM

### DIFF
--- a/bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
+++ b/bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
@@ -96,7 +96,7 @@ metadata:
     description: The MongoDB Atlas Kubernetes Operator enables easy management of Clusters in MongoDB Atlas
     operators.operatorframework.io/builder: operator-sdk-v1.7.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: mongodb-atlas-kubernetes.v0.6.7
+  name: mongodb-atlas-kubernetes.v0.6.8
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -440,7 +440,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/ecosystem-appeng/mongodb-atlas-operator:0.6.7
+                image: quay.io/ecosystem-appeng/mongodb-atlas-operator:0.6.8
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:
@@ -493,7 +493,7 @@ spec:
         serviceAccountName: mongodb-atlas-operator
     strategy: deployment
   installModes:
-  - supported: true
+  - supported: false
     type: OwnNamespace
   - supported: false
     type: SingleNamespace
@@ -516,4 +516,4 @@ spec:
   maturity: beta
   provider:
     name: MongoDB, Inc
-  version: 0.6.7
+  version: 0.6.8

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -8,4 +8,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/ecosystem-appeng/mongodb-atlas-operator
-  newTag: 0.6.7
+  newTag: 0.6.8

--- a/config/manifests/bases/mongodb-atlas-kubernetes.clusterserviceversion.yaml
+++ b/config/manifests/bases/mongodb-atlas-kubernetes.clusterserviceversion.yaml
@@ -157,7 +157,7 @@ spec:
       deployments: null
     strategy: ""
   installModes:
-  - supported: true
+  - supported: false
     type: OwnNamespace
   - supported: false
     type: SingleNamespace


### PR DESCRIPTION
This PR is to remove the namespace level installment via OLM for two reasons:
1) Original Atlas Operator only supports cluster level install
2) There is an issue when the operator is deployed in namespace-level that the operator's service account does not have permission to create registration configmap in dbaas-operator namespace. We can add the namespace level support later on if we find a solution for this issue.