### PR TITLE
Fix security context issue for OLM installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ bundle: manifests kustomize ## Generate bundle manifests and metadata, update se
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build --load-restrictor LoadRestrictionsNone config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	sed -i .bak '/runAsNonRoot: true/d' "./bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml"
-	sed -i .bak '/runAsUser: 2000/d' "./bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml"
+	sed -i .bak '/runAsUser: 1000380001/d' "./bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml"
 	rm ./bundle/manifests/*.bak
 	operator-sdk bundle validate ./bundle
 

--- a/bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
+++ b/bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
@@ -96,7 +96,7 @@ metadata:
     description: The MongoDB Atlas Kubernetes Operator enables easy management of Clusters in MongoDB Atlas
     operators.operatorframework.io/builder: operator-sdk-v1.7.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: mongodb-atlas-kubernetes.v0.6.12
+  name: mongodb-atlas-kubernetes.v0.6.13
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -433,7 +433,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/ecosystem-appeng/mongodb-atlas-operator:0.6.12
+                image: quay.io/ecosystem-appeng/mongodb-atlas-operator:0.6.13
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:
@@ -458,7 +458,6 @@ spec:
                 securityContext:
                   allowPrivilegeEscalation: false
               securityContext:
-                runAsUser: 1000380001
               serviceAccountName: mongodb-atlas-operator
               terminationGracePeriodSeconds: 10
       permissions:
@@ -510,4 +509,4 @@ spec:
   maturity: beta
   provider:
     name: MongoDB, Inc
-  version: 0.6.12
+  version: 0.6.13

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -8,4 +8,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/ecosystem-appeng/mongodb-atlas-operator
-  newTag: 0.6.12
+  newTag: 0.6.13


### PR DESCRIPTION
Currently, runAsUser is hardcoded to 1000380001, leading to installation error:
Error creating: pods "mongodb-atlas-operator-6b66cd5df7-" is forbidden: unable to validate against any security context constraint: [spec.containers[0].securityContext.runAsUser: Invalid value: 1000380001: must be in the ranges: [1000370000, 1000379999]]

This PR is to reset the security context when the atlas operator is bundled for OLM installation.