### PR TITLE
Fix issue when inventoryRef namespace is different from MongoDBAtlasConnection namespace

### DIFF
--- a/bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
+++ b/bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
@@ -96,7 +96,7 @@ metadata:
     description: The MongoDB Atlas Kubernetes Operator enables easy management of Clusters in MongoDB Atlas
     operators.operatorframework.io/builder: operator-sdk-v1.7.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: mongodb-atlas-kubernetes.v0.6.15
+  name: mongodb-atlas-kubernetes.v0.6.16
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -443,7 +443,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/ecosystem-appeng/mongodb-atlas-operator:0.6.15
+                image: quay.io/ecosystem-appeng/mongodb-atlas-operator:0.6.16
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:
@@ -519,4 +519,4 @@ spec:
   maturity: beta
   provider:
     name: MongoDB, Inc
-  version: 0.6.15
+  version: 0.6.16

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -8,4 +8,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/ecosystem-appeng/mongodb-atlas-operator
-  newTag: 0.6.15
+  newTag: 0.6.16

--- a/config/samples/dbaas_v1alpha1_atlasconnection.yaml
+++ b/config/samples/dbaas_v1alpha1_atlasconnection.yaml
@@ -2,7 +2,9 @@ apiVersion: dbaas.redhat.com/v1alpha1
 kind: MongoDBAtlasConnection
 metadata:
   name: test-connection
+  namespace: my-namespace
 spec:
-  inventory:
+  inventoryRef:
     name: test-inventory
+    namespace: mongodb-atlas-system
   instanceID: 606b2ffbc9a90e310e642482

--- a/config/samples/dbaas_v1alpha1_atlasinventory.yaml
+++ b/config/samples/dbaas_v1alpha1_atlasinventory.yaml
@@ -3,8 +3,6 @@ kind: MongoDBAtlasInventory
 metadata:
   name: test-inventory
 spec:
-  provider:
-    name: mongodbatlas
   credentialsRef:
     name: my-atlas-key
     namespace: mongodb-atlas-system

--- a/pkg/controller/atlasconnection/atlasconnection_controller.go
+++ b/pkg/controller/atlasconnection/atlasconnection_controller.go
@@ -108,7 +108,12 @@ func (r *MongoDBAtlasConnectionReconciler) Reconcile(cx context.Context, req ctr
 	}(conn)
 
 	inventory := &dbaas.MongoDBAtlasInventory{}
-	if err := r.Client.Get(cx, types.NamespacedName{Namespace: req.Namespace, Name: conn.Spec.InventoryRef.Name}, inventory); err != nil {
+	namespace := conn.Spec.InventoryRef.Namespace
+	if len(namespace) == 0 {
+		//Namespace is not populated in InventoryRef, default to the request's namespace
+		namespace = req.Namespace
+	}
+	if err := r.Client.Get(cx, types.NamespacedName{Namespace: namespace, Name: conn.Spec.InventoryRef.Name}, inventory); err != nil {
 		if errors.IsNotFound(err) {
 			// CR deleted since request queued, child objects getting GC'd, no requeue
 			log.Info("MongoDBAtlasInventory resource not found, has been deleted")


### PR DESCRIPTION
This PR is to fix the inventory look-up issue when the inventoryRef.Namespace is different from the MongoDBAtlasConnection. Tested in the lab successfully.