### PR TITLE
DBAAS-135 change connection properties exposed to align with SBO mongo work

### DIFF
--- a/bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
+++ b/bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
@@ -65,12 +65,14 @@ metadata:
           "apiVersion": "dbaas.redhat.com/v1alpha1",
           "kind": "MongoDBAtlasConnection",
           "metadata": {
-            "name": "test-connection"
+            "name": "test-connection",
+            "namespace": "my-namespace"
           },
           "spec": {
             "instanceID": "606b2ffbc9a90e310e642482",
-            "inventory": {
-              "name": "test-inventory"
+            "inventoryRef": {
+              "name": "test-inventory",
+              "namespace": "mongodb-atlas-system"
             }
           }
         },
@@ -84,9 +86,6 @@ metadata:
             "credentialsRef": {
               "name": "my-atlas-key",
               "namespace": "mongodb-atlas-system"
-            },
-            "provider": {
-              "name": "mongodbatlas"
             }
           }
         }
@@ -96,7 +95,7 @@ metadata:
     description: The MongoDB Atlas Kubernetes Operator enables easy management of Clusters in MongoDB Atlas
     operators.operatorframework.io/builder: operator-sdk-v1.7.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: mongodb-atlas-kubernetes.v0.6.16
+  name: mongodb-atlas-kubernetes.v0.6.17
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -443,7 +442,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/ecosystem-appeng/mongodb-atlas-operator:0.6.16
+                image: quay.io/ecosystem-appeng/mongodb-atlas-operator:0.6.17
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:
@@ -519,4 +518,4 @@ spec:
   maturity: beta
   provider:
     name: MongoDB, Inc
-  version: 0.6.16
+  version: 0.6.17

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -8,4 +8,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/ecosystem-appeng/mongodb-atlas-operator
-  newTag: 0.6.16
+  newTag: 0.6.17

--- a/pkg/api/dbaas/mongodbatlasconnection_types.go
+++ b/pkg/api/dbaas/mongodbatlasconnection_types.go
@@ -27,6 +27,7 @@ const (
 	ConnectionStringsStandardSrvKey = "connectionStringsStandardSrv"
 	ConnectionStringsStandardKey    = "connectionStringsStandard"
 	InstanceIDKey                   = "instanceID"
+	HostKey                         = "host"
 	ProviderKey                     = "provider"
 	Provider                        = "Red Hat DBaaS / MongoDB Atlas"
 	ServiceBindingTypeKey           = "type"

--- a/pkg/controller/atlasconnection/atlasconnection_controller.go
+++ b/pkg/controller/atlasconnection/atlasconnection_controller.go
@@ -18,6 +18,7 @@ package atlasconnection
 
 import (
 	"context"
+	"strings"
 
 	"fmt"
 	"math/rand"
@@ -352,6 +353,18 @@ func (r *MongoDBAtlasConnectionReconciler) deleteDBUserFromAtlas(conn *dbaas.Mon
 	return nil
 }
 
+// getHost retrieves host from the standard srv connection string
+func getHost(connectionStringStandardSrv string) string {
+	tokens := strings.Split(connectionStringStandardSrv, "//")
+	var host string
+	if len(tokens) < 2 {
+		host = connectionStringStandardSrv
+	} else {
+		host = tokens[1]
+	}
+	return host
+}
+
 // getOwnedConfigMap returns a configmap object with ownership set
 func getOwnedConfigMap(connection *dbaas.MongoDBAtlasConnection, connectionStringStandardSrv, connectionStringStandard string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
@@ -384,6 +397,7 @@ func getOwnedConfigMap(connection *dbaas.MongoDBAtlasConnection, connectionStrin
 			dbaas.ServiceBindingTypeKey:           dbaas.ServiceBindingType,
 			dbaas.ConnectionStringsStandardSrvKey: connectionStringStandardSrv,
 			dbaas.ConnectionStringsStandardKey:    connectionStringStandard,
+			dbaas.HostKey:                         getHost(connectionStringStandardSrv),
 		},
 	}
 }


### PR DESCRIPTION
This PR is to parse the connection strings and store the derived host in the connection configmap.
Tested on the lab successfully. 