### PR TITLE
DBAAS-140 MongoDB Atlas Operator with updated service binding attributes

### DIFF
--- a/bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
+++ b/bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
@@ -95,7 +95,7 @@ metadata:
     description: The MongoDB Atlas Kubernetes Operator enables easy management of Clusters in MongoDB Atlas
     operators.operatorframework.io/builder: operator-sdk-v1.7.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: mongodb-atlas-kubernetes.v0.6.18
+  name: mongodb-atlas-kubernetes.v0.6.21
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -442,7 +442,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/ecosystem-appeng/mongodb-atlas-operator:0.6.18
+                image: quay.io/ecosystem-appeng/mongodb-atlas-operator:0.6.21
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:
@@ -518,4 +518,4 @@ spec:
   maturity: beta
   provider:
     name: MongoDB, Inc
-  version: 0.6.18
+  version: 0.6.21

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -8,4 +8,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/ecosystem-appeng/mongodb-atlas-operator
-  newTag: 0.6.18
+  newTag: 0.6.21

--- a/pkg/api/dbaas/mongodbatlasconnection_types.go
+++ b/pkg/api/dbaas/mongodbatlasconnection_types.go
@@ -28,10 +28,12 @@ const (
 	ConnectionStringsStandardKey    = "connectionStringsStandard"
 	InstanceIDKey                   = "instanceID"
 	HostKey                         = "host"
+	SrvKey                          = "srv"
 	ProviderKey                     = "provider"
 	Provider                        = "Red Hat DBaaS / MongoDB Atlas"
 	ServiceBindingTypeKey           = "type"
-	ServiceBindingType              = "MongoDB"
+	ServiceBindingType              = "mongodb"
+	DefaultDatabase                 = "admin"
 )
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.

--- a/pkg/controller/atlasconnection/atlasconnection_controller.go
+++ b/pkg/controller/atlasconnection/atlasconnection_controller.go
@@ -290,11 +290,11 @@ func (r *MongoDBAtlasConnectionReconciler) getSecret(namespace, name string) (*c
 //createDBUserInAtlas create the database user in Atlas
 func (r *MongoDBAtlasConnectionReconciler) createDBUserInAtlas(conn *dbaas.MongoDBAtlasConnection, projectID, dbUserName, dbPassword string, inventory *dbaas.MongoDBAtlasInventory, log *zap.SugaredLogger) (ctrl.Result, error) {
 	dbUser := &mongodbatlas.DatabaseUser{
-		DatabaseName: "admin",
+		DatabaseName: dbaas.DefaultDatabase,
 		GroupID:      projectID,
 		Roles: []mongodbatlas.Role{
 			{
-				DatabaseName: "admin",
+				DatabaseName: dbaas.DefaultDatabase,
 				RoleName:     "readWriteAnyDatabase",
 			},
 		},
@@ -393,11 +393,10 @@ func getOwnedConfigMap(connection *dbaas.MongoDBAtlasConnection, connectionStrin
 			},
 		},
 		Data: map[string]string{
-			dbaas.ProviderKey:                     dbaas.Provider,
-			dbaas.ServiceBindingTypeKey:           dbaas.ServiceBindingType,
-			dbaas.ConnectionStringsStandardSrvKey: connectionStringStandardSrv,
-			dbaas.ConnectionStringsStandardKey:    connectionStringStandard,
-			dbaas.HostKey:                         getHost(connectionStringStandardSrv),
+			dbaas.ProviderKey:           dbaas.Provider,
+			dbaas.ServiceBindingTypeKey: dbaas.ServiceBindingType,
+			dbaas.HostKey:               getHost(connectionStringStandardSrv),
+			dbaas.SrvKey:                "true",
 		},
 	}
 }


### PR DESCRIPTION
This PR is to update MongoDBAtlasConnection controller to populate the connecon detail configmap as follows:
1) change "type" value to lower case "mongodb"
2) Add new field "srv" indicating whether the connection attribute "host" is for mongodb SRV. 
3) Remove remove connectionStringStandardSrv & connectionStringStandard properties

Sample connectioninfo configmap data:
  host: dbcreatedinatalas.iojsa.mongodb.net
  provider: Red Hat DBaaS / MongoDB Atlas
  srv: "true"
  type: mongodb
