### PR TITLE
dbaas bundle build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,13 +30,14 @@ endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
 # Image URL to use all building/pushing image targets
-IMG ?= controller:$(VERSION)
+IMG ?= controller
+IMGVERSION ?= $(IMG):$(VERSION)
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
-BUNDLE_IMG ?= controller-bundle:$(VERSION)
+BUNDLE_IMG ?= $(IMG)-bundle:$(VERSION)
 
 # The image tag given to the resulting catalog image (e.g. make catalog-build CATALOG_IMG=example.com/operator-catalog:0.2.0).
-CATALOG_IMG ?= controller-catalog:$(VERSION)
+CATALOG_IMG ?= $(IMG)-catalog:latest
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -140,11 +141,8 @@ endef
 .PHONY: bundle
 bundle: manifests kustomize ## Generate bundle manifests and metadata, update security context for OpenShift, then validate generated files.
 	operator-sdk generate kustomize manifests -q --apis-dir=pkg/api
-	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
-	$(KUSTOMIZE) build --load-restrictor LoadRestrictionsNone config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
-	sed -i .bak '/runAsNonRoot: true/d' "./bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml"
-	sed -i .bak '/runAsUser: 1000380001/d' "./bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml"
-	rm ./bundle/manifests/*.bak
+	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMGVERSION)
+	$(KUSTOMIZE) build --load-restrictor LoadRestrictionsNone config/manifests | operator-sdk generate bundle -q --overwrite --manifests --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	operator-sdk bundle validate ./bundle
 
 .PHONY: bundle-build
@@ -156,10 +154,10 @@ bundle-push: ## Push the bundle image.
 	docker push $(BUNDLE_IMG)
 
 docker-build: ## Build the docker image
-	docker build -t ${IMG} .
+	docker build -t $(IMGVERSION) .
 
 docker-push: ## Push the docker image
-	docker push ${IMG}
+	docker push $(IMGVERSION)
 
 # Additional make goals
 .PHONY: run-kind
@@ -216,7 +214,7 @@ catalog-build: opm ## Build a catalog image.
 # Push the catalog image.
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
-	$(MAKE) docker-push IMG=$(CATALOG_IMG)
+	docker push $(CATALOG_IMG)
 
 go-test-dbaas: ## Run unit test for AtlasConnection, AtlasInventory and DBaaSProvider controllers
 	CGO_ENABLED=0 go test ./pkg/controller/atlasconnection/... ./pkg/controller/atlasinventory/... ./pkg/controller/dbaasprovider/...

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -1,4 +1,6 @@
 FROM scratch
+
+# RH OLM annotations
 LABEL com.redhat.openshift.versions="v4.5-v4.8"
 LABEL com.redhat.delivery.backport=true
 LABEL com.redhat.delivery.operator.bundle=true
@@ -10,7 +12,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=mongodb-atlas-kubernetes
 LABEL operators.operatorframework.io.bundle.channels.v1=beta
 LABEL operators.operatorframework.io.bundle.channel.default.v1=beta
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.7.1+git
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.10.0+git
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/atlas.mongodb.com_atlasclusters.yaml
+++ b/bundle/manifests/atlas.mongodb.com_atlasclusters.yaml
@@ -24,10 +24,14 @@ spec:
         description: AtlasCluster is the Schema for the atlasclusters API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -35,50 +39,74 @@ spec:
             description: AtlasClusterSpec defines the desired state of AtlasCluster
             properties:
               autoScaling:
-                description: Collection of settings that configures auto-scaling information for the cluster. If you specify the autoScaling object, you must also specify the providerSettings.autoScaling object.
+                description: Collection of settings that configures auto-scaling information
+                  for the cluster. If you specify the autoScaling object, you must
+                  also specify the providerSettings.autoScaling object.
                 properties:
                   autoIndexingEnabled:
-                    description: Flag that indicates whether autopilot mode for Performance Advisor is enabled. The default is false.
+                    description: Flag that indicates whether autopilot mode for Performance
+                      Advisor is enabled. The default is false.
                     type: boolean
                   compute:
-                    description: Collection of settings that configure how a cluster might scale its cluster tier and whether the cluster can scale down.
+                    description: Collection of settings that configure how a cluster
+                      might scale its cluster tier and whether the cluster can scale
+                      down.
                     properties:
                       enabled:
-                        description: Flag that indicates whether cluster tier auto-scaling is enabled. The default is false.
+                        description: Flag that indicates whether cluster tier auto-scaling
+                          is enabled. The default is false.
                         type: boolean
                       maxInstanceSize:
-                        description: 'Maximum instance size to which your cluster can automatically scale (such as M40). Atlas requires this parameter if "autoScaling.compute.enabled" : true.'
+                        description: 'Maximum instance size to which your cluster
+                          can automatically scale (such as M40). Atlas requires this
+                          parameter if "autoScaling.compute.enabled" : true.'
                         type: string
                       minInstanceSize:
-                        description: 'Minimum instance size to which your cluster can automatically scale (such as M10). Atlas requires this parameter if "autoScaling.compute.scaleDownEnabled" : true.'
+                        description: 'Minimum instance size to which your cluster
+                          can automatically scale (such as M10). Atlas requires this
+                          parameter if "autoScaling.compute.scaleDownEnabled" : true.'
                         type: string
                       scaleDownEnabled:
-                        description: 'Flag that indicates whether the cluster tier may scale down. Atlas requires this parameter if "autoScaling.compute.enabled" : true.'
+                        description: 'Flag that indicates whether the cluster tier
+                          may scale down. Atlas requires this parameter if "autoScaling.compute.enabled"
+                          : true.'
                         type: boolean
                     type: object
                   diskGBEnabled:
-                    description: Flag that indicates whether disk auto-scaling is enabled. The default is true.
+                    description: Flag that indicates whether disk auto-scaling is
+                      enabled. The default is true.
                     type: boolean
                 type: object
               biConnector:
-                description: Configuration of BI Connector for Atlas on this cluster. The MongoDB Connector for Business Intelligence for Atlas (BI Connector) is only available for M10 and larger clusters.
+                description: Configuration of BI Connector for Atlas on this cluster.
+                  The MongoDB Connector for Business Intelligence for Atlas (BI Connector)
+                  is only available for M10 and larger clusters.
                 properties:
                   enabled:
-                    description: Flag that indicates whether or not BI Connector for Atlas is enabled on the cluster.
+                    description: Flag that indicates whether or not BI Connector for
+                      Atlas is enabled on the cluster.
                     type: boolean
                   readPreference:
-                    description: Source from which the BI Connector for Atlas reads data. Each BI Connector for Atlas read preference contains a distinct combination of readPreference and readPreferenceTags options.
+                    description: Source from which the BI Connector for Atlas reads
+                      data. Each BI Connector for Atlas read preference contains a
+                      distinct combination of readPreference and readPreferenceTags
+                      options.
                     type: string
                 type: object
               clusterType:
-                description: Type of the cluster that you want to create. The parameter is required if replicationSpecs are set or if Global Clusters are deployed.
+                description: Type of the cluster that you want to create. The parameter
+                  is required if replicationSpecs are set or if Global Clusters are
+                  deployed.
                 enum:
                 - REPLICASET
                 - SHARDED
                 - GEOSHARDED
                 type: string
               diskSizeGB:
-                description: Capacity, in gigabytes, of the host's root volume. Increase this number to add capacity, up to a maximum possible value of 4096 (i.e., 4 TB). This value must be a positive integer. The parameter is required if replicationSpecs are configured.
+                description: Capacity, in gigabytes, of the host's root volume. Increase
+                  this number to add capacity, up to a maximum possible value of 4096
+                  (i.e., 4 TB). This value must be a positive integer. The parameter
+                  is required if replicationSpecs are configured.
                 maximum: 4096
                 minimum: 0
                 type: integer
@@ -91,9 +119,11 @@ spec:
                 - NONE
                 type: string
               labels:
-                description: Collection of key-value pairs that tag and categorize the cluster. Each key and value has a maximum length of 255 characters.
+                description: Collection of key-value pairs that tag and categorize
+                  the cluster. Each key and value has a maximum length of 255 characters.
                 items:
-                  description: LabelSpec contains key-value pairs that tag and categorize the Cluster/DBUser
+                  description: LabelSpec contains key-value pairs that tag and categorize
+                    the Cluster/DBUser
                   properties:
                     key:
                       maxLength: 255
@@ -109,10 +139,13 @@ spec:
                 description: Version of the cluster to deploy.
                 type: string
               name:
-                description: Name of the cluster as it appears in Atlas. After Atlas creates the cluster, you can't change its name.
+                description: Name of the cluster as it appears in Atlas. After Atlas
+                  creates the cluster, you can't change its name.
                 type: string
               numShards:
-                description: Positive integer that specifies the number of shards to deploy for a sharded cluster. The parameter is required if replicationSpecs are configured
+                description: Positive integer that specifies the number of shards
+                  to deploy for a sharded cluster. The parameter is required if replicationSpecs
+                  are configured
                 maximum: 50
                 minimum: 1
                 type: integer
@@ -120,10 +153,12 @@ spec:
                 description: Flag that indicates whether the cluster should be paused.
                 type: boolean
               pitEnabled:
-                description: Flag that indicates the cluster uses continuous cloud backups.
+                description: Flag that indicates the cluster uses continuous cloud
+                  backups.
                 type: boolean
               projectRef:
-                description: Project is a reference to AtlasProject resource the cluster belongs to
+                description: Project is a reference to AtlasProject resource the cluster
+                  belongs to
                 properties:
                   name:
                     description: Name is the name of the Kubernetes Resource
@@ -135,59 +170,84 @@ spec:
                 - name
                 type: object
               providerBackupEnabled:
-                description: Applicable only for M10+ clusters. Flag that indicates if the cluster uses Cloud Backups for backups.
+                description: Applicable only for M10+ clusters. Flag that indicates
+                  if the cluster uses Cloud Backups for backups.
                 type: boolean
               providerSettings:
-                description: Configuration for the provisioned hosts on which MongoDB runs. The available options are specific to the cloud service provider.
+                description: Configuration for the provisioned hosts on which MongoDB
+                  runs. The available options are specific to the cloud service provider.
                 properties:
                   autoScaling:
-                    description: Range of instance sizes to which your cluster can scale.
+                    description: Range of instance sizes to which your cluster can
+                      scale.
                     properties:
                       autoIndexingEnabled:
-                        description: Flag that indicates whether autopilot mode for Performance Advisor is enabled. The default is false.
+                        description: Flag that indicates whether autopilot mode for
+                          Performance Advisor is enabled. The default is false.
                         type: boolean
                       compute:
-                        description: Collection of settings that configure how a cluster might scale its cluster tier and whether the cluster can scale down.
+                        description: Collection of settings that configure how a cluster
+                          might scale its cluster tier and whether the cluster can
+                          scale down.
                         properties:
                           enabled:
-                            description: Flag that indicates whether cluster tier auto-scaling is enabled. The default is false.
+                            description: Flag that indicates whether cluster tier
+                              auto-scaling is enabled. The default is false.
                             type: boolean
                           maxInstanceSize:
-                            description: 'Maximum instance size to which your cluster can automatically scale (such as M40). Atlas requires this parameter if "autoScaling.compute.enabled" : true.'
+                            description: 'Maximum instance size to which your cluster
+                              can automatically scale (such as M40). Atlas requires
+                              this parameter if "autoScaling.compute.enabled" : true.'
                             type: string
                           minInstanceSize:
-                            description: 'Minimum instance size to which your cluster can automatically scale (such as M10). Atlas requires this parameter if "autoScaling.compute.scaleDownEnabled" : true.'
+                            description: 'Minimum instance size to which your cluster
+                              can automatically scale (such as M10). Atlas requires
+                              this parameter if "autoScaling.compute.scaleDownEnabled"
+                              : true.'
                             type: string
                           scaleDownEnabled:
-                            description: 'Flag that indicates whether the cluster tier may scale down. Atlas requires this parameter if "autoScaling.compute.enabled" : true.'
+                            description: 'Flag that indicates whether the cluster
+                              tier may scale down. Atlas requires this parameter if
+                              "autoScaling.compute.enabled" : true.'
                             type: boolean
                         type: object
                       diskGBEnabled:
-                        description: Flag that indicates whether disk auto-scaling is enabled. The default is true.
+                        description: Flag that indicates whether disk auto-scaling
+                          is enabled. The default is true.
                         type: boolean
                     type: object
                   backingProviderName:
-                    description: 'Cloud service provider on which the host for a multi-tenant cluster is provisioned. This setting only works when "providerSetting.providerName" : "TENANT" and "providerSetting.instanceSizeName" : M2 or M5.'
+                    description: 'Cloud service provider on which the host for a multi-tenant
+                      cluster is provisioned. This setting only works when "providerSetting.providerName"
+                      : "TENANT" and "providerSetting.instanceSizeName" : M2 or M5.'
                     enum:
                     - AWS
                     - GCP
                     - AZURE
                     type: string
                   diskIOPS:
-                    description: Disk IOPS setting for AWS storage. Set only if you selected AWS as your cloud service provider.
+                    description: Disk IOPS setting for AWS storage. Set only if you
+                      selected AWS as your cloud service provider.
                     format: int64
                     type: integer
                   diskTypeName:
-                    description: Type of disk if you selected Azure as your cloud service provider.
+                    description: Type of disk if you selected Azure as your cloud
+                      service provider.
                     type: string
                   encryptEBSVolume:
-                    description: Flag that indicates whether the Amazon EBS encryption feature encrypts the host's root volume for both data at rest within the volume and for data moving between the volume and the cluster.
+                    description: Flag that indicates whether the Amazon EBS encryption
+                      feature encrypts the host's root volume for both data at rest
+                      within the volume and for data moving between the volume and
+                      the cluster.
                     type: boolean
                   instanceSizeName:
-                    description: Atlas provides different cluster tiers, each with a default storage capacity and RAM size. The cluster you select is used for all the data-bearing hosts in your cluster tier.
+                    description: Atlas provides different cluster tiers, each with
+                      a default storage capacity and RAM size. The cluster you select
+                      is used for all the data-bearing hosts in your cluster tier.
                     type: string
                   providerName:
-                    description: Cloud service provider on which Atlas provisions the hosts.
+                    description: Cloud service provider on which Atlas provisions
+                      the hosts.
                     enum:
                     - AWS
                     - GCP
@@ -195,10 +255,13 @@ spec:
                     - TENANT
                     type: string
                   regionName:
-                    description: Physical location of your MongoDB cluster. The region you choose can affect network latency for clients accessing your databases.
+                    description: Physical location of your MongoDB cluster. The region
+                      you choose can affect network latency for clients accessing
+                      your databases.
                     type: string
                   volumeType:
-                    description: Disk IOPS setting for AWS storage. Set only if you selected AWS as your cloud service provider.
+                    description: Disk IOPS setting for AWS storage. Set only if you
+                      selected AWS as your cloud service provider.
                     enum:
                     - STANDARD
                     - PROVISIONED
@@ -210,37 +273,57 @@ spec:
               replicationSpecs:
                 description: Configuration for cluster regions.
                 items:
-                  description: ReplicationSpec represents a configuration for cluster regions
+                  description: ReplicationSpec represents a configuration for cluster
+                    regions
                   properties:
                     numShards:
-                      description: Number of shards to deploy in each specified zone. The default value is 1.
+                      description: Number of shards to deploy in each specified zone.
+                        The default value is 1.
                       format: int64
                       type: integer
                     regionsConfig:
                       additionalProperties:
-                        description: RegionsConfig describes the region’s priority in elections and the number and type of MongoDB nodes Atlas deploys to the region.
+                        description: RegionsConfig describes the region’s priority
+                          in elections and the number and type of MongoDB nodes Atlas
+                          deploys to the region.
                         properties:
                           analyticsNodes:
-                            description: The number of analytics nodes for Atlas to deploy to the region. Analytics nodes are useful for handling analytic data such as reporting queries from BI Connector for Atlas. Analytics nodes are read-only, and can never become the primary. If you do not specify this option, no analytics nodes are deployed to the region.
+                            description: The number of analytics nodes for Atlas to
+                              deploy to the region. Analytics nodes are useful for
+                              handling analytic data such as reporting queries from
+                              BI Connector for Atlas. Analytics nodes are read-only,
+                              and can never become the primary. If you do not specify
+                              this option, no analytics nodes are deployed to the
+                              region.
                             format: int64
                             type: integer
                           electableNodes:
-                            description: Number of electable nodes for Atlas to deploy to the region. Electable nodes can become the primary and can facilitate local reads.
+                            description: Number of electable nodes for Atlas to deploy
+                              to the region. Electable nodes can become the primary
+                              and can facilitate local reads.
                             format: int64
                             type: integer
                           priority:
-                            description: Election priority of the region. For regions with only replicationSpecs[n].regionsConfig.<region>.readOnlyNodes, set this value to 0.
+                            description: Election priority of the region. For regions
+                              with only replicationSpecs[n].regionsConfig.<region>.readOnlyNodes,
+                              set this value to 0.
                             format: int64
                             type: integer
                           readOnlyNodes:
-                            description: Number of read-only nodes for Atlas to deploy to the region. Read-only nodes can never become the primary, but can facilitate local-reads.
+                            description: Number of read-only nodes for Atlas to deploy
+                              to the region. Read-only nodes can never become the
+                              primary, but can facilitate local-reads.
                             format: int64
                             type: integer
                         type: object
-                      description: Configuration for a region. Each regionsConfig object describes the region's priority in elections and the number and type of MongoDB nodes that Atlas deploys to the region.
+                      description: Configuration for a region. Each regionsConfig
+                        object describes the region's priority in elections and the
+                        number and type of MongoDB nodes that Atlas deploys to the
+                        region.
                       type: object
                     zoneName:
-                      description: Name for the zone in a Global Cluster. Don't provide this value if clusterType is not GEOSHARDED.
+                      description: Name for the zone in a Global Cluster. Don't provide
+                        this value if clusterType is not GEOSHARDED.
                       type: string
                   type: object
                 type: array
@@ -253,16 +336,20 @@ spec:
             description: AtlasClusterStatus defines the observed state of AtlasCluster.
             properties:
               conditions:
-                description: Conditions is the list of statuses showing the current state of the Atlas Custom Resource
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
                 items:
-                  description: Condition describes the state of an Atlas Custom Resource at a certain point.
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another.
+                      description: Last time the condition transitioned from one status
+                        to another.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition.
+                      description: A human readable message indicating details about
+                        the transition.
                       type: string
                     reason:
                       description: The reason for the condition's last transition.
@@ -279,21 +366,36 @@ spec:
                   type: object
                 type: array
               connectionStrings:
-                description: ConnectionStrings is a set of connection strings that your applications use to connect to this cluster.
+                description: ConnectionStrings is a set of connection strings that
+                  your applications use to connect to this cluster.
                 properties:
                   private:
-                    description: Network-peering-endpoint-aware mongodb:// connection strings for each interface VPC endpoint you configured to connect to this cluster. Atlas returns this parameter only if you created a network peering connection to this cluster.
+                    description: Network-peering-endpoint-aware mongodb:// connection
+                      strings for each interface VPC endpoint you configured to connect
+                      to this cluster. Atlas returns this parameter only if you created
+                      a network peering connection to this cluster.
                     type: string
                   privateEndpoint:
-                    description: Private endpoint connection strings. Each object describes the connection strings you can use to connect to this cluster through a private endpoint. Atlas returns this parameter only if you deployed a private endpoint to all regions to which you deployed this cluster's nodes.
+                    description: Private endpoint connection strings. Each object
+                      describes the connection strings you can use to connect to this
+                      cluster through a private endpoint. Atlas returns this parameter
+                      only if you deployed a private endpoint to all regions to which
+                      you deployed this cluster's nodes.
                     items:
-                      description: PrivateEndpoint connection strings. Each object describes the connection strings you can use to connect to this cluster through a private endpoint. Atlas returns this parameter only if you deployed a private endpoint to all regions to which you deployed this cluster's nodes.
+                      description: PrivateEndpoint connection strings. Each object
+                        describes the connection strings you can use to connect to
+                        this cluster through a private endpoint. Atlas returns this
+                        parameter only if you deployed a private endpoint to all regions
+                        to which you deployed this cluster's nodes.
                       properties:
                         connectionString:
-                          description: Private-endpoint-aware mongodb:// connection string for this private endpoint.
+                          description: Private-endpoint-aware mongodb:// connection
+                            string for this private endpoint.
                           type: string
                         endpoints:
-                          description: Private endpoint through which you connect to Atlas when you use connectionStrings.privateEndpoint[n].connectionString or connectionStrings.privateEndpoint[n].srvConnectionString.
+                          description: Private endpoint through which you connect
+                            to Atlas when you use connectionStrings.privateEndpoint[n].connectionString
+                            or connectionStrings.privateEndpoint[n].srvConnectionString.
                           items:
                             description: Endpoint through which you connect to Atlas
                             properties:
@@ -301,43 +403,60 @@ spec:
                                 description: Unique identifier of the private endpoint.
                                 type: string
                               providerName:
-                                description: Cloud provider to which you deployed the private endpoint. Atlas returns AWS or AZURE.
+                                description: Cloud provider to which you deployed
+                                  the private endpoint. Atlas returns AWS or AZURE.
                                 type: string
                               region:
-                                description: Region to which you deployed the private endpoint.
+                                description: Region to which you deployed the private
+                                  endpoint.
                                 type: string
                             type: object
                           type: array
                         srvConnectionString:
-                          description: Private-endpoint-aware mongodb+srv:// connection string for this private endpoint.
+                          description: Private-endpoint-aware mongodb+srv:// connection
+                            string for this private endpoint.
                           type: string
                         type:
-                          description: "Type of MongoDB process that you connect to with the connection strings \n Atlas returns: \n • MONGOD for replica sets, or \n • MONGOS for sharded clusters"
+                          description: "Type of MongoDB process that you connect to
+                            with the connection strings \n Atlas returns: \n • MONGOD
+                            for replica sets, or \n • MONGOS for sharded clusters"
                           type: string
                       type: object
                     type: array
                   privateSrv:
-                    description: Network-peering-endpoint-aware mongodb+srv:// connection strings for each interface VPC endpoint you configured to connect to this cluster. Atlas returns this parameter only if you created a network peering connection to this cluster. Use this URI format if your driver supports it. If it doesn't, use connectionStrings.private.
+                    description: Network-peering-endpoint-aware mongodb+srv:// connection
+                      strings for each interface VPC endpoint you configured to connect
+                      to this cluster. Atlas returns this parameter only if you created
+                      a network peering connection to this cluster. Use this URI format
+                      if your driver supports it. If it doesn't, use connectionStrings.private.
                     type: string
                   standard:
                     description: Public mongodb:// connection string for this cluster.
                     type: string
                   standardSrv:
-                    description: Public mongodb+srv:// connection string for this cluster.
+                    description: Public mongodb+srv:// connection string for this
+                      cluster.
                     type: string
                 type: object
               mongoDBVersion:
-                description: MongoDBVersion is the version of MongoDB the cluster runs, in <major version>.<minor version> format.
+                description: MongoDBVersion is the version of MongoDB the cluster
+                  runs, in <major version>.<minor version> format.
                 type: string
               mongoURIUpdated:
-                description: MongoURIUpdated is a timestamp in ISO 8601 date and time format in UTC when the connection string was last updated. The connection string changes if you update any of the other values.
+                description: MongoURIUpdated is a timestamp in ISO 8601 date and time
+                  format in UTC when the connection string was last updated. The connection
+                  string changes if you update any of the other values.
                 type: string
               observedGeneration:
-                description: ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of. The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                description: ObservedGeneration indicates the generation of the resource
+                  specification that the Atlas Operator is aware of. The Atlas Operator
+                  updates this field to the 'metadata.generation' as soon as it starts
+                  reconciliation of the resource.
                 format: int64
                 type: integer
               stateName:
-                description: 'StateName is the current state of the cluster. The possible states are: IDLE, CREATING, UPDATING, DELETING, DELETED, REPAIRING'
+                description: 'StateName is the current state of the cluster. The possible
+                  states are: IDLE, CREATING, UPDATING, DELETING, DELETED, REPAIRING'
                 type: string
             required:
             - conditions

--- a/bundle/manifests/atlas.mongodb.com_atlasdatabaseusers.yaml
+++ b/bundle/manifests/atlas.mongodb.com_atlasdatabaseusers.yaml
@@ -28,27 +28,38 @@ spec:
         description: AtlasDatabaseUser is the Schema for the Atlas Database User API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: AtlasDatabaseUserSpec defines the desired state of Database User in Atlas
+            description: AtlasDatabaseUserSpec defines the desired state of Database
+              User in Atlas
             properties:
               databaseName:
                 default: admin
-                description: DatabaseName is a Database against which Atlas authenticates the user. Default value is 'admin'.
+                description: DatabaseName is a Database against which Atlas authenticates
+                  the user. Default value is 'admin'.
                 type: string
               deleteAfterDate:
-                description: DeleteAfterDate is a timestamp in ISO 8601 date and time format in UTC after which Atlas deletes the user. The specified date must be in the future and within one week.
+                description: DeleteAfterDate is a timestamp in ISO 8601 date and time
+                  format in UTC after which Atlas deletes the user. The specified
+                  date must be in the future and within one week.
                 type: string
               labels:
-                description: Labels is an array containing key-value pairs that tag and categorize the database user. Each key and value has a maximum length of 255 characters.
+                description: Labels is an array containing key-value pairs that tag
+                  and categorize the database user. Each key and value has a maximum
+                  length of 255 characters.
                 items:
-                  description: LabelSpec contains key-value pairs that tag and categorize the Cluster/DBUser
+                  description: LabelSpec contains key-value pairs that tag and categorize
+                    the Cluster/DBUser
                   properties:
                     key:
                       maxLength: 255
@@ -61,7 +72,8 @@ spec:
                   type: object
                 type: array
               passwordSecretRef:
-                description: PasswordSecret is a reference to the Secret keeping the user password.
+                description: PasswordSecret is a reference to the Secret keeping the
+                  user password.
                 properties:
                   name:
                     description: Name is the name of the Kubernetes Resource
@@ -70,7 +82,8 @@ spec:
                 - name
                 type: object
               projectRef:
-                description: Project is a reference to AtlasProject resource the user belongs to
+                description: Project is a reference to AtlasProject resource the user
+                  belongs to
                 properties:
                   name:
                     description: Name is the name of the Kubernetes Resource
@@ -82,18 +95,26 @@ spec:
                 - name
                 type: object
               roles:
-                description: Roles is an array of this user's roles and the databases / collections on which the roles apply. A role allows the user to perform particular actions on the specified database.
+                description: Roles is an array of this user's roles and the databases
+                  / collections on which the roles apply. A role allows the user to
+                  perform particular actions on the specified database.
                 items:
-                  description: RoleSpec allows the user to perform particular actions on the specified database. A role on the admin database can include privileges that apply to the other databases as well.
+                  description: RoleSpec allows the user to perform particular actions
+                    on the specified database. A role on the admin database can include
+                    privileges that apply to the other databases as well.
                   properties:
                     collectionName:
-                      description: CollectionName is a collection for which the role applies.
+                      description: CollectionName is a collection for which the role
+                        applies.
                       type: string
                     databaseName:
-                      description: DatabaseName is a database on which the user has the specified role. A role on the admin database can include privileges that apply to the other databases.
+                      description: DatabaseName is a database on which the user has
+                        the specified role. A role on the admin database can include
+                        privileges that apply to the other databases.
                       type: string
                     roleName:
-                      description: RoleName is a name of the role. This value can either be a built-in role or a custom role.
+                      description: RoleName is a name of the role. This value can
+                        either be a built-in role or a custom role.
                       type: string
                   required:
                   - databaseName
@@ -102,15 +123,22 @@ spec:
                 minItems: 1
                 type: array
               scopes:
-                description: Scopes is an array of clusters and Atlas Data Lakes that this user has access to.
+                description: Scopes is an array of clusters and Atlas Data Lakes that
+                  this user has access to.
                 items:
-                  description: ScopeSpec if present a database user only have access to the indicated resource (Cluster or Atlas Data Lake) if none is given then it has access to all. It's highly recommended to restrict the access of the database users only to a limited set of resources.
+                  description: ScopeSpec if present a database user only have access
+                    to the indicated resource (Cluster or Atlas Data Lake) if none
+                    is given then it has access to all. It's highly recommended to
+                    restrict the access of the database users only to a limited set
+                    of resources.
                   properties:
                     name:
-                      description: Name is a name of the cluster or Atlas Data Lake that the user has access to.
+                      description: Name is a name of the cluster or Atlas Data Lake
+                        that the user has access to.
                       type: string
                     type:
-                      description: Type is a type of resource that the user has access to.
+                      description: Type is a type of resource that the user has access
+                        to.
                       enum:
                       - CLUSTER
                       - DATA_LAKE
@@ -133,16 +161,20 @@ spec:
             description: AtlasDatabaseUserStatus defines the observed state of AtlasProject
             properties:
               conditions:
-                description: Conditions is the list of statuses showing the current state of the Atlas Custom Resource
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
                 items:
-                  description: Condition describes the state of an Atlas Custom Resource at a certain point.
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another.
+                      description: Last time the condition transitioned from one status
+                        to another.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition.
+                      description: A human readable message indicating details about
+                        the transition.
                       type: string
                     reason:
                       description: The reason for the condition's last transition.
@@ -162,11 +194,15 @@ spec:
                 description: UserName is the current name of database user.
                 type: string
               observedGeneration:
-                description: ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of. The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                description: ObservedGeneration indicates the generation of the resource
+                  specification that the Atlas Operator is aware of. The Atlas Operator
+                  updates this field to the 'metadata.generation' as soon as it starts
+                  reconciliation of the resource.
                 format: int64
                 type: integer
               passwordVersion:
-                description: PasswordVersion is the 'ResourceVersion' of the password Secret that the Atlas Operator is aware of
+                description: PasswordVersion is the 'ResourceVersion' of the password
+                  Secret that the Atlas Operator is aware of
                 type: string
             required:
             - conditions

--- a/bundle/manifests/atlas.mongodb.com_atlasprojects.yaml
+++ b/bundle/manifests/atlas.mongodb.com_atlasprojects.yaml
@@ -28,18 +28,26 @@ spec:
         description: AtlasProject is the Schema for the atlasprojects API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: AtlasProjectSpec defines the desired state of Project in Atlas
+            description: AtlasProjectSpec defines the desired state of Project in
+              Atlas
             properties:
               connectionSecretRef:
-                description: ConnectionSecret is the name of the Kubernetes Secret which contains the information about the way to connect to Atlas (organization ID, API keys). The default Operator connection configuration will be used if not provided.
+                description: ConnectionSecret is the name of the Kubernetes Secret
+                  which contains the information about the way to connect to Atlas
+                  (organization ID, API keys). The default Operator connection configuration
+                  will be used if not provided.
                 properties:
                   name:
                     description: Name is the name of the Kubernetes Resource
@@ -48,20 +56,25 @@ spec:
                 - name
                 type: object
               name:
-                description: Name is the name of the Project that is created in Atlas by the Operator if it doesn't exist yet.
+                description: Name is the name of the Project that is created in Atlas
+                  by the Operator if it doesn't exist yet.
                 type: string
               privateEndpoints:
-                description: PrivateEndpoints is a list of Private Endpoints configured for the current Project.
+                description: PrivateEndpoints is a list of Private Endpoints configured
+                  for the current Project.
                 items:
                   properties:
                     id:
-                      description: Unique identifier of the private endpoint you created in your AWS VPC or Azure Vnet.
+                      description: Unique identifier of the private endpoint you created
+                        in your AWS VPC or Azure Vnet.
                       type: string
                     ip:
-                      description: Private IP address of the private endpoint network interface you created in your Azure VNet.
+                      description: Private IP address of the private endpoint network
+                        interface you created in your Azure VNet.
                       type: string
                     provider:
-                      description: Cloud provider for which you want to retrieve a private endpoint service. Atlas accepts AWS or AZURE.
+                      description: Cloud provider for which you want to retrieve a
+                        private endpoint service. Atlas accepts AWS or AZURE.
                       enum:
                       - AWS
                       - GCP
@@ -69,7 +82,8 @@ spec:
                       - TENANT
                       type: string
                     region:
-                      description: Cloud provider region for which you want to create the private endpoint service.
+                      description: Cloud provider region for which you want to create
+                        the private endpoint service.
                       type: string
                   required:
                   - provider
@@ -77,20 +91,24 @@ spec:
                   type: object
                 type: array
               projectIpAccessList:
-                description: ProjectIPAccessList allows to enable the IP Access List for the Project. See more information at https://docs.atlas.mongodb.com/reference/api/ip-access-list/add-entries-to-access-list/
+                description: ProjectIPAccessList allows to enable the IP Access List
+                  for the Project. See more information at https://docs.atlas.mongodb.com/reference/api/ip-access-list/add-entries-to-access-list/
                 items:
                   properties:
                     awsSecurityGroup:
-                      description: Unique identifier of AWS security group in this access list entry.
+                      description: Unique identifier of AWS security group in this
+                        access list entry.
                       type: string
                     cidrBlock:
-                      description: Range of IP addresses in CIDR notation in this access list entry.
+                      description: Range of IP addresses in CIDR notation in this
+                        access list entry.
                       type: string
                     comment:
                       description: Comment associated with this access list entry.
                       type: string
                     deleteAfterDate:
-                      description: Timestamp in ISO 8601 date and time format in UTC after which Atlas deletes the temporary access list entry.
+                      description: Timestamp in ISO 8601 date and time format in UTC
+                        after which Atlas deletes the temporary access list entry.
                       type: string
                     ipAddress:
                       description: Entry using an IP address in this access list entry.
@@ -104,16 +122,20 @@ spec:
             description: AtlasProjectStatus defines the observed state of AtlasProject
             properties:
               conditions:
-                description: Conditions is the list of statuses showing the current state of the Atlas Custom Resource
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
                 items:
-                  description: Condition describes the state of an Atlas Custom Resource at a certain point.
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another.
+                      description: Last time the condition transitioned from one status
+                        to another.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition.
+                      description: A human readable message indicating details about
+                        the transition.
                       type: string
                     reason:
                       description: The reason for the condition's last transition.
@@ -130,20 +152,26 @@ spec:
                   type: object
                 type: array
               expiredIpAccessList:
-                description: The list of IP Access List entries that are expired due to 'deleteAfterDate' being less than the current date. Note, that this field is updated by the Atlas Operator only after specification changes
+                description: The list of IP Access List entries that are expired due
+                  to 'deleteAfterDate' being less than the current date. Note, that
+                  this field is updated by the Atlas Operator only after specification
+                  changes
                 items:
                   properties:
                     awsSecurityGroup:
-                      description: Unique identifier of AWS security group in this access list entry.
+                      description: Unique identifier of AWS security group in this
+                        access list entry.
                       type: string
                     cidrBlock:
-                      description: Range of IP addresses in CIDR notation in this access list entry.
+                      description: Range of IP addresses in CIDR notation in this
+                        access list entry.
                       type: string
                     comment:
                       description: Comment associated with this access list entry.
                       type: string
                     deleteAfterDate:
-                      description: Timestamp in ISO 8601 date and time format in UTC after which Atlas deletes the temporary access list entry.
+                      description: Timestamp in ISO 8601 date and time format in UTC
+                        after which Atlas deletes the temporary access list entry.
                       type: string
                     ipAddress:
                       description: Entry using an IP address in this access list entry.
@@ -154,19 +182,30 @@ spec:
                 description: The ID of the Atlas Project
                 type: string
               observedGeneration:
-                description: ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of. The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                description: ObservedGeneration indicates the generation of the resource
+                  specification that the Atlas Operator is aware of. The Atlas Operator
+                  updates this field to the 'metadata.generation' as soon as it starts
+                  reconciliation of the resource.
                 format: int64
                 type: integer
               privateEndpoints:
-                description: The list of private endpoints configured for current project
+                description: The list of private endpoints configured for current
+                  project
                 items:
-                  description: PrivateEndpoint connection strings. Each object describes the connection strings you can use to connect to this cluster through a private endpoint. Atlas returns this parameter only if you deployed a private endpoint to all regions to which you deployed this cluster's nodes.
+                  description: PrivateEndpoint connection strings. Each object describes
+                    the connection strings you can use to connect to this cluster
+                    through a private endpoint. Atlas returns this parameter only
+                    if you deployed a private endpoint to all regions to which you
+                    deployed this cluster's nodes.
                   properties:
                     connectionString:
-                      description: Private-endpoint-aware mongodb:// connection string for this private endpoint.
+                      description: Private-endpoint-aware mongodb:// connection string
+                        for this private endpoint.
                       type: string
                     endpoints:
-                      description: Private endpoint through which you connect to Atlas when you use connectionStrings.privateEndpoint[n].connectionString or connectionStrings.privateEndpoint[n].srvConnectionString.
+                      description: Private endpoint through which you connect to Atlas
+                        when you use connectionStrings.privateEndpoint[n].connectionString
+                        or connectionStrings.privateEndpoint[n].srvConnectionString.
                       items:
                         description: Endpoint through which you connect to Atlas
                         properties:
@@ -174,18 +213,23 @@ spec:
                             description: Unique identifier of the private endpoint.
                             type: string
                           providerName:
-                            description: Cloud provider to which you deployed the private endpoint. Atlas returns AWS or AZURE.
+                            description: Cloud provider to which you deployed the
+                              private endpoint. Atlas returns AWS or AZURE.
                             type: string
                           region:
-                            description: Region to which you deployed the private endpoint.
+                            description: Region to which you deployed the private
+                              endpoint.
                             type: string
                         type: object
                       type: array
                     srvConnectionString:
-                      description: Private-endpoint-aware mongodb+srv:// connection string for this private endpoint.
+                      description: Private-endpoint-aware mongodb+srv:// connection
+                        string for this private endpoint.
                       type: string
                     type:
-                      description: "Type of MongoDB process that you connect to with the connection strings \n Atlas returns: \n • MONGOD for replica sets, or \n • MONGOS for sharded clusters"
+                      description: "Type of MongoDB process that you connect to with
+                        the connection strings \n Atlas returns: \n • MONGOD for replica
+                        sets, or \n • MONGOS for sharded clusters"
                       type: string
                   type: object
                 type: array

--- a/bundle/manifests/dbaas.redhat.com_mongodbatlasconnections.yaml
+++ b/bundle/manifests/dbaas.redhat.com_mongodbatlasconnections.yaml
@@ -21,13 +21,18 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: MongoDBAtlasConnection is the Schema for the MongoDBAtlasConnections API
+        description: MongoDBAtlasConnection is the Schema for the MongoDBAtlasConnections
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -35,7 +40,8 @@ spec:
             description: DBaaSConnectionSpec defines the desired state of DBaaSConnection
             properties:
               instanceID:
-                description: The ID of the instance to connect to, as seen in the Status of the referenced DBaaSInventory
+                description: The ID of the instance to connect to, as seen in the
+                  Status of the referenced DBaaSInventory
                 type: string
               inventoryRef:
                 description: A reference to the relevant DBaaSInventory CR
@@ -56,23 +62,45 @@ spec:
             properties:
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
@@ -85,7 +113,11 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -98,17 +130,21 @@ spec:
                   type: object
                 type: array
               connectionInfoRef:
-                description: A ConfigMap holding non-sensitive information needed for connecting to the DB instance
+                description: A ConfigMap holding non-sensitive information needed
+                  for connecting to the DB instance
                 properties:
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
               credentialsRef:
-                description: Secret holding the credentials needed for accessing the DB instance
+                description: Secret holding the credentials needed for accessing the
+                  DB instance
                 properties:
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
             type: object

--- a/bundle/manifests/dbaas.redhat.com_mongodbatlasinventories.yaml
+++ b/bundle/manifests/dbaas.redhat.com_mongodbatlasinventories.yaml
@@ -21,21 +21,31 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: MongoDBAtlasInventory is the Schema for the MongoDBAtlasInventory API
+        description: MongoDBAtlasInventory is the Schema for the MongoDBAtlasInventory
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: DBaaSInventorySpec defines the Inventory Spec to be used by provider operators
+            description: DBaaSInventorySpec defines the Inventory Spec to be used
+              by provider operators
             properties:
               credentialsRef:
-                description: The Secret containing the provider-specific connection credentials to use with its API endpoint. The format of the Secret is specified in the provider’s operator in its DBaaSProvider CR (CredentialFields key). It is recommended to place the Secret in a namespace with limited accessibility.
+                description: The Secret containing the provider-specific connection
+                  credentials to use with its API endpoint. The format of the Secret
+                  is specified in the provider’s operator in its DBaaSProvider CR
+                  (CredentialFields key). It is recommended to place the Secret in
+                  a namespace with limited accessibility.
                 properties:
                   name:
                     description: The name for object of known type
@@ -48,27 +58,50 @@ spec:
             - credentialsRef
             type: object
           status:
-            description: DBaaSInventoryStatus defines the Inventory status to be used by provider operators
+            description: DBaaSInventoryStatus defines the Inventory status to be used
+              by provider operators
             properties:
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
@@ -81,7 +114,11 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -98,12 +135,16 @@ spec:
                 items:
                   properties:
                     instanceID:
-                      description: A provider-specific identifier for this instance in the database service. It may contain one or more pieces of information used by the provider operator to identify the instance on the database service.
+                      description: A provider-specific identifier for this instance
+                        in the database service. It may contain one or more pieces
+                        of information used by the provider operator to identify the
+                        instance on the database service.
                       type: string
                     instanceInfo:
                       additionalProperties:
                         type: string
-                      description: Any other provider-specific information related to this instance
+                      description: Any other provider-specific information related
+                        to this instance
                       type: object
                     name:
                       description: The name of this instance in the database service

--- a/bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
+++ b/bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
@@ -92,10 +92,11 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Database
-    description: The MongoDB Atlas Kubernetes Operator enables easy management of Clusters in MongoDB Atlas
-    operators.operatorframework.io/builder: operator-sdk-v1.7.1+git
+    description: The MongoDB Atlas Kubernetes Operator enables easy management of
+      Clusters in MongoDB Atlas
+    operators.operatorframework.io/builder: operator-sdk-v1.10.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: mongodb-atlas-kubernetes.v0.6.1
+  name: mongodb-atlas-kubernetes.v0.1.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -116,12 +117,14 @@ spec:
       kind: AtlasProject
       name: atlasprojects.atlas.mongodb.com
       version: v1
-    - description: MongoDBAtlasConnection is the Schema for the MongoDBAtlasConnections API
+    - description: MongoDBAtlasConnection is the Schema for the MongoDBAtlasConnections
+        API
       displayName: Mongo DBAtlas Connection
       kind: MongoDBAtlasConnection
       name: mongodbatlasconnections.dbaas.redhat.com
       version: v1alpha1
-    - description: MongoDBAtlasInventory is the Schema for the MongoDBAtlasInventory API
+    - description: MongoDBAtlasInventory is the Schema for the MongoDBAtlasInventory
+        API
       displayName: Mongo DBAtlas Inventory
       kind: MongoDBAtlasInventory
       name: mongodbatlasinventories.dbaas.redhat.com
@@ -442,7 +445,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: registry.connect.redhat.com/mongodb/mongodb-atlas-kubernetes-operator:0.6.1
+                image: quay.io/mongodb/mongodb-atlas-kubernetes-dbaas:0.1.0
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:
@@ -517,6 +520,4 @@ spec:
   maturity: beta
   provider:
     name: MongoDB, Inc
-  version: 0.6.1
-  replaces: mongodb-atlas-kubernetes.v0.6.0
-  
+  version: 0.1.0

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: mongodb-atlas-kubernetes
   operators.operatorframework.io.bundle.channels.v1: beta
   operators.operatorframework.io.bundle.channel.default.v1: beta
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.7.1+git
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.10.0+git
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/config/crd/bases/atlas.mongodb.com_atlasclusters.yaml
+++ b/config/crd/bases/atlas.mongodb.com_atlasclusters.yaml
@@ -166,7 +166,6 @@ spec:
                     type: string
                 required:
                 - name
-                - namespace
                 type: object
               providerBackupEnabled:
                 description: Applicable only for M10+ clusters. Flag that indicates

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -7,5 +7,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: registry.connect.redhat.com/mongodb/mongodb-atlas-kubernetes-operator
-  newTag: 0.6.1
+  newName: quay.io/mongodb/mongodb-atlas-kubernetes-dbaas
+  newTag: 0.1.0

--- a/config/manifests/bases/mongodb-atlas-kubernetes.clusterserviceversion.yaml
+++ b/config/manifests/bases/mongodb-atlas-kubernetes.clusterserviceversion.yaml
@@ -5,7 +5,8 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     categories: Database
-    description: The MongoDB Atlas Kubernetes Operator enables easy management of Clusters in MongoDB Atlas
+    description: The MongoDB Atlas Kubernetes Operator enables easy management of
+      Clusters in MongoDB Atlas
   name: mongodb-atlas-kubernetes.v0.0.0
   namespace: placeholder
 spec:
@@ -27,12 +28,14 @@ spec:
       kind: AtlasProject
       name: atlasprojects.atlas.mongodb.com
       version: v1
-    - description: MongoDBAtlasConnection is the Schema for the MongoDBAtlasConnections API
+    - description: MongoDBAtlasConnection is the Schema for the MongoDBAtlasConnections
+        API
       displayName: Mongo DBAtlas Connection
       kind: MongoDBAtlasConnection
       name: mongodbatlasconnections.dbaas.redhat.com
       version: v1alpha1
-    - description: MongoDBAtlasInventory is the Schema for the MongoDBAtlasInventory API
+    - description: MongoDBAtlasInventory is the Schema for the MongoDBAtlasInventory
+        API
       displayName: Mongo DBAtlas Inventory
       kind: MongoDBAtlasInventory
       name: mongodbatlasinventories.dbaas.redhat.com


### PR DESCRIPTION
using operator-sdk 1.10.1.
with newer versions we hit this issue - https://github.com/operator-framework/operator-sdk/issues/5244

command used to build the dbaas images/catalog was the following -
```bash
$ IMG=quay.io/mongodb/mongodb-atlas-kubernetes-dbaas VERSION=0.1.0 make docker-build docker-push bundle bundle-build bundle-push catalog-build catalog-push
```

Signed-off-by: Tommy Hughes <tohughes@redhat.com>