### PR TITLE
Revert Dockerfile to use user 1001

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,5 @@ COPY --from=builder /workspace/manager .
 COPY hack/licenses licenses
 COPY --from=builder /workspace/dbaas_provider.yaml .
 
-USER nonroot:nonroot
-
+USER 1001:0
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
The user nonroot in Dockerfile should be reverted back to 1001.