### PR TITLE
Allow MongoDBAtlasInventory spec.credentialsRef.namespace to be empty

### DIFF
--- a/pkg/api/dbaas/mongodbatlasinventory_types.go
+++ b/pkg/api/dbaas/mongodbatlasinventory_types.go
@@ -52,7 +52,11 @@ func init() {
 
 func (p *MongoDBAtlasInventory) ConnectionSecretObjectKey() *client.ObjectKey {
 	if p.Spec.CredentialsRef != nil {
-		key := kube.ObjectKey(p.Spec.CredentialsRef.Namespace, p.Spec.CredentialsRef.Name)
+		ns := p.Spec.CredentialsRef.Namespace
+		if len(ns) == 0 {
+			ns = p.Namespace
+		}
+		key := kube.ObjectKey(ns, p.Spec.CredentialsRef.Name)
 		return &key
 	}
 	return nil


### PR DESCRIPTION
This PR is part of the fix for DBAAS-175: Add validation logic to DBaaSInventory creation with webhook. It makes MongoDBAtlasInventory spec.credentialsRef.namespace optional, and when it is absent, the namespace of the DBaaSInventory should be used instead to retrieve the secret for the credentials.

Tested successfully in local stack.

Verification steps:
1) Deploy the operator in an OpenShift 4.8 cluster.
2) Create a secret my-atlas-key with 3 fields: orgId, privateApiKey and publicApiKey.
3) Create a MongoDBAtlasInventory CR like below. Note that the namespace of the CR and credentialsRef are absent.
apiVersion: dbaas.redhat.com/v1alpha1
kind: MongoDBAtlasInventory
metadata:
  name: jianrzha
spec:
  provider:
    name: Red Hat DBaaS / MongoDB Atlas
  credentialsRef:
    name: my-atlas-key
4) Expect output: the CR should be created successfully. Check the CR status and confirm that the CR gets reconciled successfully.
Sample output:
oc get mongodbatlasinventory.dbaas.redhat.com/jianrzha -o yaml
apiVersion: dbaas.redhat.com/v1alpha1
kind: MongoDBAtlasInventory
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"dbaas.redhat.com/v1alpha1","kind":"MongoDBAtlasInventory","metadata":{"annotations":{},"name":"jianrzha","namespace":"jianrong"},"spec":{"credentialsRef":{"name":"my-atlas-key"},"provider":{"name":"Red Hat DBaaS / MongoDB Atlas"}}}
  creationTimestamp: "2021-10-14T21:22:34Z"
  generation: 1
  name: jianrzha
  namespace: jianrong
  resourceVersion: "639547"
  uid: 46e810c5-47d2-48b5-b5b8-af8550c788e7
spec:
  credentialsRef:
    name: my-atlas-key
status:
  conditions:
  - lastTransitionTime: "2021-10-14T21:24:58Z"
    message: Spec sync OK
    reason: SyncOK
    status: "True"
    type: SpecSynced
  instances:
  - instanceID: 608df625aa94426b4167e45f
    instanceInfo:
      connectionStringsStandardSrv: mongodb+srv://dbaas-cluster1.h38mo.mongodb.net
      instanceSizeName: M0
      projectID: 608df5e652e1944293e8584a
      projectName: Project 1
      providerName: TENANT
      regionName: US_EAST_1
    name: DBaaS-Cluster1
  - instanceID: 60807282b4ab8d3b3c84be53
    instanceInfo:
      connectionStringsStandardSrv: mongodb+srv://test.iojsa.mongodb.net
      instanceSizeName: M10
      projectID: 6065e15b16c0731bf3a2aefa
      projectName: Project 2
      providerName: AWS
      regionName: US_EAST_1
    name: test
  - instanceID: 606b2ffbc9a90e310e642482
    instanceInfo:
      connectionStringsStandardSrv: mongodb+srv://dbcreatedinatalas.iojsa.mongodb.net
      instanceSizeName: M0
      projectID: 6065e15b16c0731bf3a2aefa
      projectName: Project 2
      providerName: TENANT
      regionName: US_EAST_1
    name: DBCreatedInAtalas
  - instanceID: 60b7a72f4877d05880c487d2
    instanceInfo:
      connectionStringsStandardSrv: mongodb+srv://test.fbbz5.mongodb.net
      instanceSizeName: M10
      projectID: 60b798fea37f9f09acc1a154
      projectName: jianrzha
      providerName: AWS
      regionName: US_EAST_1
    name: test

