### PR TITLE
DBAAS-287 Instance provisioning error with Atlas Project credentials …

### DIFF
--- a/pkg/controller/atlasinventory/inventory.go
+++ b/pkg/controller/atlasinventory/inventory.go
@@ -64,6 +64,12 @@ func GetClusterInfo(atlasClient *mongodbatlas.Client, projectName, clusterName s
 // GetInstance returns instance info as required by DBaaS Operator
 func GetInstance(project mongodbatlas.Project, cluster mongodbatlas.Cluster) dbaasv1alpha1.Instance {
 	// Convert state names to "Creating", "Ready", "Deleting", "Deleted" etc.
+	// Pending - provisioning not yet started
+	// Creating - provisioning in progress
+	// Updating - cluster updating in progress
+	// Deleting - cluster deletion in progress
+	// Deleted - cluster has been deleted
+	// Ready - cluster provisioning complete
 	phase := strings.Title(strings.ToLower(cluster.StateName))
 	if cluster.StateName == "IDLE" {
 		phase = "Ready"


### PR DESCRIPTION
This PR fixes the issues on handling Atlas Project during provisioning. An Atlas Project is required to provision a new Atlas Cluster, and the same project can have multiple clusters, however for each project, at most one free trial instance (M0) is allowed. In addition, since the AtlasProject CR uses the same credentials as MongoDBAtlasInventory, the AtlasProject CR must be located in the same namespace as the inventory CR, because currently, MongoDB Atlas Operator core does not support credentials cross namepsaces. In addition when a cluster is being provisioned, there is some period when the cluster has not been created in Atlas, and the MongDBInstance should indicate that provisioning is pending.