### PR TITLE
DBAAS-350 AtlasProject CR deletion gets stuck if the credentials secret has been deleted or credentials are expired

### DIFF
--- a/pkg/controller/atlasproject/atlasproject_controller.go
+++ b/pkg/controller/atlasproject/atlasproject_controller.go
@@ -91,6 +91,9 @@ func (r *AtlasProjectReconciler) Reconcile(context context.Context, req ctrl.Req
 
 	connection, err := atlas.ReadConnection(log, r.Client, r.GlobalAPISecret, project.ConnectionSecretObjectKey())
 	if err != nil {
+		if !project.GetDeletionTimestamp().IsZero() && isDeletionFinalizerPresent(project) {
+			_ = r.removeDeletionFinalizer(context, project)
+		}
 		result = workflow.Terminate(workflow.AtlasCredentialsNotProvided, err.Error())
 		ctx.SetConditionFromResult(status.ProjectReadyType, result)
 		return result.ReconcileResult(), nil


### PR DESCRIPTION
This PR fix the AtlasProject CR deletion issue when the credentials secret has been deleted or credentials are expired. The deletion will get stuck unless the CR's finalizer is removed manually.

Since the secret no longer exists (or the credentials have been expired), the AtlasProject CR is no longer good. Deletion of this CR should succeed with this fix.

Tested successfully in my RHPDS env.