### PR TITLE
DBAAS-368 MongoDB Database instance Provision failed

### DIFF
--- a/pkg/api/v1/atlasproject_types.go
+++ b/pkg/api/v1/atlasproject_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -108,6 +109,43 @@ func (p *AtlasProject) UpdateStatus(conditions []status.Condition, options ...st
 		v := o.(status.AtlasProjectStatusOption)
 		v(&p.Status)
 	}
+}
+
+func (p *AtlasProject) GetCondition(condType status.ConditionType) *status.Condition {
+	for _, cond := range p.Status.Conditions {
+		if cond.Type == condType {
+			return &cond
+		}
+	}
+	return nil
+}
+
+// CheckConditions check AtlasProject conditions
+// First check if ReadyType condition exists and is True
+// Then check if a condition of ProjectReadyType, ClusterReadyType, IPAccessListReadyType or PrivateEndpointReadyType condition exists and is False
+// returns nil otherwise
+func (p *AtlasProject) CheckConditions() *status.Condition {
+	cond := p.GetCondition(status.ReadyType)
+	if cond != nil && cond.Status == corev1.ConditionTrue {
+		return cond
+	}
+	cond = p.GetCondition(status.ProjectReadyType)
+	if cond != nil && cond.Status == corev1.ConditionFalse {
+		return cond
+	}
+	cond = p.GetCondition(status.ClusterReadyType)
+	if cond != nil && cond.Status == corev1.ConditionFalse {
+		return cond
+	}
+	cond = p.GetCondition(status.IPAccessListReadyType)
+	if cond != nil && cond.Status == corev1.ConditionFalse {
+		return cond
+	}
+	cond = p.GetCondition(status.PrivateEndpointReadyType)
+	if cond != nil && cond.Status == corev1.ConditionFalse {
+		return cond
+	}
+	return nil
 }
 
 // ************************************ Builder methods *************************************************

--- a/pkg/controller/atlasinstance/atlasinstance_test.go
+++ b/pkg/controller/atlasinstance/atlasinstance_test.go
@@ -366,8 +366,6 @@ func TestAtlasInstanceReconcile(t *testing.T) {
 	clusterName := "myclusternew"
 	projectName := "myproject"
 	expectedPhase := "Pending"
-	expectedReadyCondition := "False"
-	expectedReasonString := "Pending"
 	expectedErrString := "CLUSTER_NOT_FOUND"
 	expectedRequeue := true
 	inventory := &dbaas.MongoDBAtlasInventory{
@@ -452,11 +450,6 @@ func TestAtlasInstanceReconcile(t *testing.T) {
 			Namespace: instance.Namespace,
 		}, instanceUpdated)
 	assert.NoError(t, err)
-
-	if len(expectedReadyCondition) > 0 {
-		assert.Equal(t, expectedReadyCondition, string(instanceUpdated.Status.Conditions[0].Status))
-		assert.Equal(t, expectedReasonString, instanceUpdated.Status.Conditions[0].Reason)
-	}
 	assert.Equal(t, expectedPhase, instanceUpdated.Status.Phase)
 
 	// After an instance is deleted, the corresponding atlas project should be deleted


### PR DESCRIPTION
This PR fixes the issue DBAAS-368:
1) After an atlas project is created and before starting the creation of a new cluster, the project should be ready.
2) The project name (and parameter values) should have leading and trailing spaces trimmed to avoid confusion to the users.
