### PR TITLE
Change user agent to identify RHODA usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,8 @@ manifests: controller-gen ## Generate manifests e.g. CRD, RBAC etc.
 .PHONY: fmt
 fmt: ## Run go fmt against code
 	go fmt ./...
+	find . -name "*.go" -not -path "./vendor/*" -exec gofmt -w "{}" \;
+	find . -name "*.go" -not -path "./vendor/*" -exec goimports -l "{}" \;
 
 .PHONY: vet
 vet: ## Run go vet against code

--- a/pkg/controller/atlas/client.go
+++ b/pkg/controller/atlas/client.go
@@ -28,7 +28,7 @@ func Client(atlasDomain string, connection Connection, log *zap.SugaredLogger) (
 	if err != nil {
 		return mongodbatlas.Client{}, err
 	}
-	client.UserAgent = fmt.Sprintf("%s/%s (%s;%s)", "MongoDBAtlasKubernetesOperator", ProductVersion, runtime.GOOS, runtime.GOARCH)
+	client.UserAgent = fmt.Sprintf("%s/%s (%s;%s)", "MongoDBAtlasKubernetesOperatorRHODA", ProductVersion, runtime.GOOS, runtime.GOARCH)
 
 	return *client, nil
 }


### PR DESCRIPTION
This modifies the user agent string to include "RHODA" so that we can better understand RHODA usage through our analytics layer.
