### PR TITLE
Update the release process for DBaaS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SHELL := /usr/bin/env bash
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.8.0
+VERSION ?= 0.3.0
 
 ifndef PRODUCT_VERSION
 PRODUCT_VERSION := $(shell git describe --tags --dirty --broken)
@@ -37,17 +37,19 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
 # Base registry for the operator, bundle, catalog images
 REGISTRY ?= quay.io/mongodb
-# BUNDLE_IMG defines the image:tag used for the bundle.
-# You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
-BUNDLE_IMG ?= $(REGISTRY)/$(IMG)-bundle:$(VERSION)
-
 # Image URL to use all building/pushing image targets
-IMG ?= mongodb-atlas-kubernetes
-#BUNDLE_REGISTRY ?= $(REGISTRY)/$(IMG)-operator-bundle
-OPERATOR_REGISTRY ?= $(REGISTRY)/$(IMG)
-CATALOG_REGISTRY ?= $(REGISTRY)/$(IMG)-catalog
-OPERATOR_IMAGE ?= ${OPERATOR_REGISTRY}:${VERSION}
-CATALOG_IMAGE ?= ${CATALOG_REGISTRY}:${VERSION}
+IMG ?= $(REGISTRY)/mongodb-atlas-kubernetes-dbaas
+OPERATOR_REGISTRY ?= $(IMG)
+
+OPERATOR_IMG ?= $(IMG):$(VERSION)
+# OPERATOR_IMG ?= $(IMG):latest
+
+BUNDLE_IMG ?= $(IMG)-bundle:$(VERSION)
+# BUNDLE_IMG ?= $(IMG)-bundle:latest
+
+CATALOG_IMG ?= $(IMG)-catalog:$(VERSION)
+# CATALOG_IMG ?= ${IMG}-catalog:latest
+
 TARGET_NAMESPACE ?= mongodb-atlas-operator-system-test
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -156,14 +158,14 @@ endef
 .PHONY: bundle
 bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
 	operator-sdk generate kustomize manifests -q --apis-dir=pkg/api
-	cd config/manager && $(KUSTOMIZE) edit set image controller=$(OPERATOR_IMAGE)
+	cd config/manager && $(KUSTOMIZE) edit set image controller=$(OPERATOR_IMG)
 	$(KUSTOMIZE) build --load-restrictor LoadRestrictionsNone config/manifests | operator-sdk generate bundle -q --overwrite --manifests --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	operator-sdk bundle validate ./bundle
 
 .PHONY: image
 image: manager ## Build the operator image
-	$(CONTAINER_ENGINE) build -t $(OPERATOR_IMAGE) .
-	$(CONTAINER_ENGINE) push $(OPERATOR_IMAGE)
+	$(CONTAINER_ENGINE) build -t $(OPERATOR_IMG) .
+	$(CONTAINER_ENGINE) push $(OPERATOR_IMG)
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
@@ -184,10 +186,10 @@ catalog-build: opm ## bundle bundle-push ## Build file-based bundle
 ifneq ($(origin CATALOG_BASE_IMG), undefined)
 	$(OPM) index add --container-tool $(CONTAINER_ENGINE) --mode semver --tag $(CATALOG_IMAGE) --bundles $(BUNDLE_IMGS) --from-index $(CATALOG_BASE_IMG)
 else
-	$(MAKE) image IMG=$(OPERATOR_IMAGE)
+	$(MAKE) image IMG=$(IMG)
 	CATALOG_DIR=$(CATALOG_DIR) \
 	CHANNEL=$(DEFAULT_CHANNEL) \
-	CATALOG_IMAGE=$(CATALOG_IMAGE) \
+	CATALOG_IMAGE=$(CATALOG_IMG) \
 	BUNDLE_IMAGE=$(BUNDLE_IMG) \
 	VERSION=$(VERSION) \
 	./scripts/build_catalog.sh
@@ -195,7 +197,7 @@ endif
 
 .PHONY: catalog-push
 catalog-push:
-	$(CONTAINER_ENGINE) push $(CATALOG_IMAGE)
+	$(CONTAINER_ENGINE) push $(CATALOG_IMG)
 
 .PHONY: build-subscription
 build-subscription:
@@ -207,7 +209,7 @@ build-subscription:
 .PHONY: build-catalogsource
 build-catalogsource:
 	CATALOG_DIR=$(shell dirname "$(CATALOG_DIR)") \
-	CATALOG_IMAGE=$(CATALOG_IMAGE) \
+	CATALOG_IMG=$(CATALOG_IMG) \
 	./scripts/build_catalogsource.sh
 
 .PHONY: deploy-olm
@@ -228,7 +230,7 @@ deploy-olm: bundle-build bundle-push catalog-build catalog-push build-catalogsou
 
 .PHONY: docker-push
 docker-push: ## Push the docker image
-	$(CONTAINER_ENGINE) push $(IMG)
+	$(CONTAINER_ENGINE) push $(OPERATOR_IMG)
 
 # Additional make goals
 .PHONY: run-kind

--- a/bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
+++ b/bundle/manifests/mongodb-atlas-kubernetes.clusterserviceversion.yaml
@@ -156,11 +156,12 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Database
+    containerImage: mongodb/mongodb-atlas-kubernetes-dbaas:0.3.0
     description: The MongoDB Atlas Kubernetes Operator enables easy management of
       Clusters in MongoDB Atlas
-    operators.operatorframework.io/builder: operator-sdk-v1.15.0+git
+    operators.operatorframework.io/builder: operator-sdk-v1.20.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: mongodb-atlas-kubernetes.v0.8.0
+  name: mongodb-atlas-kubernetes.v0.3.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -536,7 +537,11 @@ spec:
           - update
         serviceAccountName: mongodb-atlas-operator
       deployments:
-      - name: mongodb-atlas-operator
+      - label:
+          app.kubernetes.io/component: controller
+          app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+          app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+        name: mongodb-atlas-operator
         spec:
           replicas: 1
           selector:
@@ -573,7 +578,7 @@ spec:
                       fieldPath: metadata.namespace
                 - name: SYNC_PERIOD_MIN
                   value: "180"
-                image: quay.io/mongodb/mongodb-atlas-kubernetes:0.8.0
+                image: quay.io/mongodb/mongodb-atlas-kubernetes-dbaas:0.3.0
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:
@@ -649,4 +654,4 @@ spec:
   provider:
     name: MongoDB, Inc
   replaces: mongodb-atlas-kubernetes.v0.2.0
-  version: 0.8.0
+  version: 0.3.0

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -7,5 +7,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/mongodb/mongodb-atlas-kubernetes
-  newTag: 0.8.0
+  newName: quay.io/mongodb/mongodb-atlas-kubernetes-dbaas
+  newTag: 0.3.0


### PR DESCRIPTION
This commit updates the release procedure for DBaaS bundles and catalogs:

- https://quay.io/repository/mongodb/mongodb-atlas-kubernetes-dbaas
- https://quay.io/repository/mongodb/mongodb-atlas-kubernetes-dbaas-bundle
- https://quay.io/repository/mongodb/mongodb-atlas-kubernetes-dbaas-catalog

Also update the generated files.