### PR TITLE
DBAAS-449 Potential resource/memory leak for MongoDB Atlas Operator for DBaaSConnection

### DIFF
--- a/pkg/controller/atlasconnection/atlasconnection_test.go
+++ b/pkg/controller/atlasconnection/atlasconnection_test.go
@@ -387,7 +387,6 @@ func TestAtlasConnectionReconcile(t *testing.T) {
 				assert.NotEmpty(t, connectionUpdated.Status.ConnectionInfoRef.Name)
 				assert.NotEmpty(t, connectionUpdated.Status.CredentialsRef.Name)
 			} else {
-				assert.Nil(t, connectionUpdated.Status.ConnectionInfoRef)
 				assert.Nil(t, connectionUpdated.Status.CredentialsRef)
 			}
 		})


### PR DESCRIPTION
This PR is to enhance the mongodbatlasconnection reconciliation to avoid the potential resource leak. One such scenario: after a configmap is created, if the operator fails to create a db user in Atlas (for instance, due to a permission issue), a future reconciliation will be triggered, which can cause another configmap to get created and the first configmap becomes a "dangling" object. If the error still exists, more and more configmaps can be created, and eventually will cause the cluster to run out of the # of resources permitted, or the operator can run out of memory.

Successfully tested in local RHPDS cluster.
