### PR TITLE
DBAAS-368 MongoDB Database instance Provision failed: fix core dump issue when no atlas project CR is found

### DIFF
--- a/pkg/controller/atlasinstance/atlasinstance_controller.go
+++ b/pkg/controller/atlasinstance/atlasinstance_controller.go
@@ -306,8 +306,7 @@ func (r *MongoDBAtlasInstanceReconciler) reconcileAtlasProject(cx context.Contex
 		if err != nil {
 			return
 		}
-		// Fetch the project name from newly created CR
-		atlasProject, err = r.getAtlasProject(cx, inst)
+		atlasProject = project
 	}
 	return
 }


### PR DESCRIPTION
This PR fixes an issue in Atlas Operator that can cause the operator pod to terminate and restart when:

The user creates an inventory with API key that does not have organization owner permission.
2)The user then uses the inventory to create a DBaaSInstance.
Tested successfully in RHPDS dev env.
