### PR TITLE
DBAAS-956 MongoDB Atlas Operator incorrectly sets host to empty when processing connections

### DIFF
--- a/pkg/controller/atlasconnection/atlasconnection_test.go
+++ b/pkg/controller/atlasconnection/atlasconnection_test.go
@@ -206,6 +206,19 @@ func TestAtlasConnectionReconcile(t *testing.T) {
 			expectedStatus:      "False",
 			expectedReason:      "InventoryNotFound",
 		},
+		"InstanceNotReady": {
+			createConnection:    true,
+			configMapCreateFail: false,
+			secretCreateFail:    false,
+			instanceID:          "70b7a72f4877d05880cNoSrv",
+			inventoryReason:     "SyncOK",
+			inventoryStatus:     "True",
+			instancesPath:       "../../../test/e2e/data/atlasinventoryconditionsnosrv.json",
+			expectedErrString:   "instance connection strings are empty",
+			expectedRequeue:     false,
+			expectedStatus:      "False",
+			expectedReason:      "InstanceNotReady",
+		},
 		"ConfigMapCreateFail": {
 			createConnection:    true,
 			configMapCreateFail: true,
@@ -251,7 +264,7 @@ func TestAtlasConnectionReconcile(t *testing.T) {
 		t.Run(tcName, func(t *testing.T) {
 			instances := []dbaasv1alpha1.Instance{}
 			if len(tc.instancesPath) > 0 {
-				data, err := ioutil.ReadFile("../../../test/e2e/data/atlasinventoryexpected.json")
+				data, err := ioutil.ReadFile(tc.instancesPath)
 				assert.NoError(t, err)
 				err = json.Unmarshal(data, &instances)
 				assert.NoError(t, err)

--- a/pkg/controller/workflow/reason.go
+++ b/pkg/controller/workflow/reason.go
@@ -81,6 +81,7 @@ const (
 	MongoDBAtlasInstanceReady               ConditionReason = "Ready"
 	MongoDBAtlasInstanceAtlasUnreachable    ConditionReason = "Unreachable"
 	MongoDBAtlasInstanceInventoryNotFound   ConditionReason = "InventoryNotFound"
+	MongoDBAtlasInstanceNotReady            ConditionReason = "InstanceNotReady"
 	MongoDBAtlasInstanceClusterNotFound     ConditionReason = "AtlasClusterNotFound"
 	MongoDBAtlasInstanceBackendError        ConditionReason = "BackendError"
 	MongoDBAtlasInstanceAuthenticationError ConditionReason = "AuthenticationError"

--- a/test/e2e/data/atlasinventoryconditionsnosrv.json
+++ b/test/e2e/data/atlasinventoryconditionsnosrv.json
@@ -1,0 +1,14 @@
+[
+    {
+      "instanceID":"70b7a72f4877d05880cNoSrv",
+      "name":"testb",
+      "instanceInfo":{
+         "instanceSizeName":"M10",
+         "state":"Creating",
+         "projectID":"608df5e652e1944293e8584a",
+         "projectName":"Project 1",
+         "providerName":"AWS",
+         "regionName":"US_EAST_1"
+      }
+   }
+]


### PR DESCRIPTION
When a DBaaSConnection is created with a reference of DBaaSInstance for mongodb using the Red Hat GitOps operator, the connection CR may have its configmap created with an empty host string set. As a result, the application would fail to run as the host string from the service binding is empty.

The solution is to check if the connection string is empty before creating the configmap/secret for connections.

Fix tested on the devt cluster successfully.