### PR TITLE
Disable dbaas related controllers when OpenShift Database Access installation is not found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN go install golang.org/x/tools/cmd/goimports@latest
 
 # Copy the go source & git info
 COPY cmd/manager/main.go cmd/manager/main.go
+COPY cmd/manager/dbaas.go cmd/manager/dbaas.go
 COPY .git/ .git/
 COPY pkg/ pkg/
 COPY Makefile Makefile

--- a/Makefile
+++ b/Makefile
@@ -105,13 +105,13 @@ e2e-openshift-upgrade:
 	cd scripts && ./openshift-upgrade-test.sh
 
 .PHONY: manager
-manager: generate fmt vet ## Build manager binary
+manager: #generate fmt vet ## Build manager binary
 	@echo "Building operator with version $(VERSION)"
-	 GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) go build -o bin/manager -ldflags="-X github.com/mongodb/mongodb-atlas-kubernetes/pkg/version.Version=$(VERSION)" cmd/manager/main.go
+	 GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) go build -o bin/manager -ldflags="-X github.com/mongodb/mongodb-atlas-kubernetes/pkg/version.Version=$(VERSION)" cmd/manager/main.go cmd/manager/dbaas.go
 
 .PHONY: run
 run: generate fmt vet manifests ## Run against the configured Kubernetes cluster in ~/.kube/config
-	go run ./cmd/manager/main.go
+	go run ./cmd/manager/main.go ./cmd/manager/dbaas.go
 
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from a cluster

--- a/cmd/manager/dbaas.go
+++ b/cmd/manager/dbaas.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2023 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"fmt"
+
+	"go.uber.org/zap"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	dbaasv1beta1 "github.com/RHEcosystemAppEng/dbaas-operator/api/v1beta1"
+
+	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/atlasconnection"
+	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/atlasinstance"
+	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/atlasinventory"
+	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/dbaasprovider"
+	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/controller/watch"
+)
+
+// checkAndEnableDBaaS check if DBaaSProvider CRD is deployed and start the DBaaS related controllers
+func checkAndEnableDBaaS(mgr manager.Manager, logger *zap.Logger, config Config) (bool, error) {
+	cfg := mgr.GetConfig()
+	clientset, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return false, fmt.Errorf("unable to create clientset: %w", err)
+	}
+
+	dbaasInstalled, err := checkDBaaSCRDInstalled(clientset)
+	if err != nil {
+		return false, fmt.Errorf("unable to check OpenShift Database Access (DBaaS) Provider CRD: %w", err)
+	}
+	if dbaasInstalled {
+		if err = (&dbaasprovider.DBaaSProviderReconciler{
+			Client:    mgr.GetClient(),
+			Scheme:    mgr.GetScheme(),
+			Log:       logger.Named("controllers").Named("DBaaSProvider").Sugar(),
+			Clientset: clientset,
+		}).SetupWithManager(mgr); err != nil {
+			return false, fmt.Errorf("unable to create DBaaSProvider controller: %w", err)
+		}
+
+		if err = (&atlasinventory.MongoDBAtlasInventoryReconciler{
+			Client:          mgr.GetClient(),
+			Log:             logger.Named("controllers").Named("MongoDBAtlasInventory").Sugar(),
+			Scheme:          mgr.GetScheme(),
+			AtlasDomain:     config.AtlasDomain,
+			ResourceWatcher: watch.NewResourceWatcher(),
+			GlobalAPISecret: config.GlobalAPISecret,
+			EventRecorder:   mgr.GetEventRecorderFor("MongoDBAtlasInventory"),
+		}).SetupWithManager(mgr); err != nil {
+			return false, fmt.Errorf("unable to create MongoDBAtlasInventory controller: %w", err)
+		}
+
+		if err = (&atlasconnection.MongoDBAtlasConnectionReconciler{
+			Client:          mgr.GetClient(),
+			Clientset:       clientset,
+			Log:             logger.Named("controllers").Named("MongoDBAtlasConnection").Sugar(),
+			Scheme:          mgr.GetScheme(),
+			AtlasDomain:     config.AtlasDomain,
+			ResourceWatcher: watch.NewResourceWatcher(),
+			GlobalAPISecret: config.GlobalAPISecret,
+			EventRecorder:   mgr.GetEventRecorderFor("MongoDBAtlasConnection"),
+		}).SetupWithManager(mgr); err != nil {
+			return false, fmt.Errorf("unable to create MongoDBAtlasConnection controller: %w", err)
+		}
+
+		if err = (&atlasinstance.MongoDBAtlasInstanceReconciler{
+			Client:          mgr.GetClient(),
+			Clientset:       clientset,
+			Log:             logger.Named("controllers").Named("MongoDBAtlasInstance").Sugar(),
+			Scheme:          mgr.GetScheme(),
+			AtlasDomain:     config.AtlasDomain,
+			ResourceWatcher: watch.NewResourceWatcher(),
+			GlobalAPISecret: config.GlobalAPISecret,
+			EventRecorder:   mgr.GetEventRecorderFor("MongoDBAtlasInstance"),
+		}).SetupWithManager(mgr); err != nil {
+			return false, fmt.Errorf("unable to create MongoDBAtlasInstance controller: %w", err)
+		}
+	} else {
+		return false, nil
+	}
+	return true, nil
+}
+
+// checkDBaaSCRDInstalled checks whether dbaas provider CRD, has been created yet
+func checkDBaaSCRDInstalled(clientset kubernetes.Interface) (bool, error) {
+	resources, err := clientset.Discovery().ServerResourcesForGroupVersion(dbaasv1beta1.GroupVersion.String())
+	if err != nil {
+		if apiErrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to check DBaaSProvider CRD:%w", err)
+	}
+	for _, r := range resources.APIResources {
+		if r.Kind == dbaasProviderKind {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.11
 	github.com/Azure/go-autorest/autorest/to v0.4.0
 	github.com/Masterminds/semver v1.5.0
-	github.com/RHEcosystemAppEng/dbaas-operator v0.4.1-0.20230315151811-07a580d55781
+	github.com/RHEcosystemAppEng/dbaas-operator v0.4.1-0.20230403142057-6112a98be1a6
 	github.com/aws/aws-sdk-go v1.44.151
 	github.com/fatih/structtag v1.2.0
 	github.com/fgrosse/zaptest v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/RHEcosystemAppEng/dbaas-operator v0.4.1-0.20230315151811-07a580d55781 h1:96D/PTk+D1WgyDYPvikO1GEPDbfYHzkSAYX2NTNOPUg=
-github.com/RHEcosystemAppEng/dbaas-operator v0.4.1-0.20230315151811-07a580d55781/go.mod h1:9ATeP4fEAwadF2G/vhWsuTG1+KPmwXGxPuA7vn/E2gA=
+github.com/RHEcosystemAppEng/dbaas-operator v0.4.1-0.20230403142057-6112a98be1a6 h1:OMGk5nAUggRanNg3895zvF3l24gvr6RyL5KMZNwYoHA=
+github.com/RHEcosystemAppEng/dbaas-operator v0.4.1-0.20230403142057-6112a98be1a6/go.mod h1:9ATeP4fEAwadF2G/vhWsuTG1+KPmwXGxPuA7vn/E2gA=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=


### PR DESCRIPTION
Tested in a fresh cluster successfully:
1) if dbaas is not installed, no controllers for dbaas are started.
2) if dbaas is installed, the operator registers with dbaas successfully.

### All Submissions:

* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if there is one).
* [ ] Update docs/release-notes/release-notes.md if your changes should be included in the release notes for the next release.
